### PR TITLE
Implement fluency in Japanese

### DIFF
--- a/src/langcheck/eval/ja/__init__.py
+++ b/src/langcheck/eval/ja/__init__.py
@@ -3,11 +3,11 @@ from langcheck.eval.ja.reference_based_text_quality import (rouge1, rouge2,
                                                             rougeL,
                                                             semantic_sim)
 from langcheck.eval.ja.reference_free_text_quality import (
-    sentiment, tateishi_ono_yamada_reading_ease, toxicity)
+    fluency, sentiment, tateishi_ono_yamada_reading_ease, toxicity)
 from langcheck.eval.ja.source_based_text_quality import factual_consistency
 
 __all__ = [
     'factual_consistency', 'JanomeTokenizer', 'MeCabTokenizer', 'rouge1',
-    'rouge2', 'rougeL', 'semantic_sim', 'sentiment',
+    'rouge2', 'rougeL', 'semantic_sim', 'fluency', 'sentiment',
     'tateishi_ono_yamada_reading_ease', 'toxicity'
 ]

--- a/src/langcheck/eval/ja/reference_free_text_quality.py
+++ b/src/langcheck/eval/ja/reference_free_text_quality.py
@@ -5,7 +5,8 @@ import torch
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 from langcheck._handle_logs import _handle_logging_level
-from langcheck.eval.en.reference_free_text_quality import _toxicity_openai
+from langcheck.eval.en.reference_free_text_quality import (_fluency_openai,
+                                                           _toxicity_openai)
 from langcheck.eval.en.reference_free_text_quality import \
     sentiment as en_sentiment
 from langcheck.eval.eval_value import EvalValue
@@ -18,6 +19,11 @@ _toxicity_model_path = "Alnusjaponica/toxicity-score-multi-classification"
 _toxicity_tokenizer_path = "line-corporation/line-distilbert-base-japanese"
 _toxicity_tokenizer = None
 _toxicity_model = None
+
+_fluency_model_path = "liwii/fluency-score-classification-ja"
+_fluency_tokenizer_path = "line-corporation/line-distilbert-base-japanese"
+_fluency_tokenizer = None
+_fluency_model = None
 
 
 def sentiment(generated_outputs: List[str],
@@ -180,6 +186,91 @@ def _toxicity_local(generated_outputs: List[str]) -> List[float]:
     toxicity_scores = torch.sigmoid(output.logits[:, 0]).tolist()
 
     return toxicity_scores
+
+
+def fluency(generated_outputs: List[str],
+            prompts: Optional[List[str]] = None,
+            model_type: str = 'local',
+            openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
+    '''Calculates the fluency scores of generated outputs. This metric takes on
+    float values between [0, 1], where 0 is low fluency and 1 is high fluency.
+
+    We currently support two model types:
+    1. The 'local' type, where the our fine-tuned model is downloaded from
+    HuggingFace and run locally. This is the default model type and there is
+    no setup needed to run this.
+    2. The 'openai' type, where we use OpenAI's 'gpt-turbo-3.5' model
+    by default, in the same way as english counterpart. While the model you use
+    is configurable, please make sure to use one that supports function calling
+    (https://platform.openai.com/docs/guides/gpt/function-calling). See
+    https://github.com/citadel-ai/langcheck#evaluate-text for examples on
+    setting up the OpenAI API key.
+
+    Args:
+        generated_outputs: A list of model generated outputs to evaluate
+        prompts: An optional list of prompts used to generate the outputs.
+            Prompts are not evaluated and only used as metadata.
+        model_type: The type of model to use ('local' or 'openai'),
+            default 'local'
+        openai_args: Dict of additional args to pass in to the
+            `openai.ChatCompletion.create` function, default None
+
+    Returns:
+        An :class:`~langcheck.eval.eval_value.EvalValue` object
+    '''
+
+    assert model_type in ['local', 'openai'
+                         ], ('Unsupported model type. '
+                             'The supported ones are ["local", "openai"]')
+
+    if model_type == 'local':
+        scores = _fluency_local(generated_outputs)
+    else:  # openai
+        scores = _fluency_openai(generated_outputs, openai_args)
+
+    return EvalValue(metric_name='fluency',
+                     prompts=prompts,
+                     generated_outputs=generated_outputs,
+                     reference_outputs=None,
+                     sources=None,
+                     metric_values=scores,
+                     language='ja')
+
+
+def _fluency_local(generated_outputs: List[str]) -> List[float]:
+    '''Calculates the fluency scores of generated outputs using a fine-tuned
+    model from `line-corporation/line-distilbert-base-japanese`. This metric
+    takes on float values between [0, 1], where 0 is low fluency and 1 is high
+    fluency.
+
+    Ref:
+        https://huggingface.co/line-corporation/line-distilbert-base-japanese
+        https://huggingface.co/liwii/fluency-score-classification-ja
+
+    Args:
+        generated_outputs: A list of model generated outputs to evaluate
+
+    Returns:
+        A list of scores
+    '''
+    global _fluency_model, _fluency_tokenizer
+    _fluency_model = (
+        _fluency_model or
+        AutoModelForSequenceClassification.from_pretrained(_fluency_model_path))
+    _fluency_tokenizer = _fluency_tokenizer or AutoTokenizer.from_pretrained(
+        _fluency_tokenizer_path, trust_remote_code=True)
+
+    input_tokens = _fluency_tokenizer(generated_outputs,
+                                      return_tensors='pt',
+                                      padding=True)
+    with torch.no_grad():
+        # Probabilities of [not_fluent, fluent]
+        probs = torch.nn.functional.softmax(
+            _fluency_model(**input_tokens).logits, dim=1)
+
+    fluency_scores = probs[:, 1].tolist()
+
+    return fluency_scores
 
 
 def tateishi_ono_yamada_reading_ease(

--- a/src/langcheck/eval/ja/reference_free_text_quality.py
+++ b/src/langcheck/eval/ja/reference_free_text_quality.py
@@ -110,8 +110,8 @@ def sentiment(generated_outputs: List[str] | str,
                      language='ja')
 
 
-def toxicity(generated_outputs: List[str],
-             prompts: Optional[List[str]] = None,
+def toxicity(generated_outputs: List[str] | str,
+             prompts: Optional[List[str] | str] = None,
              model_type: str = 'local',
              openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
     '''Calculates the toxicity scores of generated outputs. This metric takes on
@@ -129,9 +129,9 @@ def toxicity(generated_outputs: List[str],
     setting up the OpenAI API key.
 
     Args:
-        generated_outputs: A list of model generated outputs to evaluate
-        prompts: An optional list of prompts used to generate the outputs.
-            Prompts are not evaluated and only used as metadata.
+        generated_outputs: The model generated output(s) to evaluate
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
         model_type: The type of model to use ('local' or 'openai'),
             default 'local'
         openai_args: Dict of additional args to pass in to the
@@ -140,7 +140,8 @@ def toxicity(generated_outputs: List[str],
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-
+    generated_outputs, prompts = validate_parameters_reference_free(
+        generated_outputs, prompts)
     assert model_type in ['local', 'openai'
                          ], ('Unsupported model type. '
                              'The supported ones are ["local", "openai"]')
@@ -192,8 +193,8 @@ def _toxicity_local(generated_outputs: List[str]) -> List[float]:
     return toxicity_scores
 
 
-def fluency(generated_outputs: List[str],
-            prompts: Optional[List[str]] = None,
+def fluency(generated_outputs: List[str] | str,
+            prompts: Optional[List[str] | str] = None,
             model_type: str = 'local',
             openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
     '''Calculates the fluency scores of generated outputs. This metric takes on
@@ -211,9 +212,9 @@ def fluency(generated_outputs: List[str],
     setting up the OpenAI API key.
 
     Args:
-        generated_outputs: A list of model generated outputs to evaluate
-        prompts: An optional list of prompts used to generate the outputs.
-            Prompts are not evaluated and only used as metadata.
+        generated_outputs: The model generated output(s) to evaluate
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
         model_type: The type of model to use ('local' or 'openai'),
             default 'local'
         openai_args: Dict of additional args to pass in to the
@@ -222,7 +223,8 @@ def fluency(generated_outputs: List[str],
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-
+    generated_outputs, prompts = validate_parameters_reference_free(
+        generated_outputs, prompts)
     assert model_type in ['local', 'openai'
                          ], ('Unsupported model type. '
                              'The supported ones are ["local", "openai"]')

--- a/src/langcheck/eval/ja/reference_free_text_quality.py
+++ b/src/langcheck/eval/ja/reference_free_text_quality.py
@@ -257,8 +257,14 @@ def _fluency_local(generated_outputs: List[str]) -> List[float]:
     _fluency_model = (
         _fluency_model or
         AutoModelForSequenceClassification.from_pretrained(_fluency_model_path))
-    _fluency_tokenizer = _fluency_tokenizer or AutoTokenizer.from_pretrained(
-        _fluency_tokenizer_path, trust_remote_code=True)
+
+    # Suppress "tokenizer class you load ... is not the same type ..." error
+    # because AutoTokenzier is suggested by the readme of the original model
+    # and "DistilBertJapaneseTokenizer", which is suggested by the warning,
+    # is not exposed to transformers.
+    with _handle_logging_level():
+        _fluency_tokenizer = _fluency_tokenizer or AutoTokenizer.from_pretrained(
+            _fluency_tokenizer_path, trust_remote_code=True, revision='main')
 
     input_tokens = _fluency_tokenizer(generated_outputs,
                                       return_tensors='pt',

--- a/src/langcheck/eval/ja/reference_free_text_quality.py
+++ b/src/langcheck/eval/ja/reference_free_text_quality.py
@@ -263,8 +263,11 @@ def _fluency_local(generated_outputs: List[str]) -> List[float]:
     # and "DistilBertJapaneseTokenizer", which is suggested by the warning,
     # is not exposed to transformers.
     with _handle_logging_level():
-        _fluency_tokenizer = _fluency_tokenizer or AutoTokenizer.from_pretrained(
-            _fluency_tokenizer_path, trust_remote_code=True, revision='main')
+        _fluency_tokenizer = (_fluency_tokenizer or
+                              AutoTokenizer.from_pretrained(
+                                  _fluency_tokenizer_path,
+                                  trust_remote_code=True,
+                                  revision='main'))
 
     input_tokens = _fluency_tokenizer(generated_outputs,
                                       return_tensors='pt',

--- a/src/langcheck/eval/ja/reference_free_text_quality.py
+++ b/src/langcheck/eval/ja/reference_free_text_quality.py
@@ -118,15 +118,22 @@ def toxicity(generated_outputs: List[str] | str,
     float values between [0, 1], where 0 is low toxicity and 1 is high toxicity.
 
     We currently support two model types:
-    1. The 'local' type, where the our fine-tuned model is downloaded from
-    HuggingFace and run locally. This is the default model type and there is
-    no setup needed to run this.
+    1. The 'local' type, where a model file is downloaded from HuggingFace and
+    run locally. This is the default model type and there is no setup needed to
+    run this.
+    The model (Alnusjaponica/toxicity-score-multi-classification) is a
+    fine-tuned model based on line-corporation/line-distilbert-base-japanese
+    model.
     2. The 'openai' type, where we use OpenAI's 'gpt-turbo-3.5' model
     by default, in the same way as english counterpart. While the model you use
     is configurable, please make sure to use one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
     https://github.com/citadel-ai/langcheck#evaluate-text for examples on
     setting up the OpenAI API key.
+
+    Ref:
+        https://huggingface.co/line-corporation/line-distilbert-base-japanese
+        https://huggingface.co/Alnusjaponica/toxicity-score-multi-classification
 
     Args:
         generated_outputs: The model generated output(s) to evaluate
@@ -201,15 +208,21 @@ def fluency(generated_outputs: List[str] | str,
     float values between [0, 1], where 0 is low fluency and 1 is high fluency.
 
     We currently support two model types:
-    1. The 'local' type, where the our fine-tuned model is downloaded from
-    HuggingFace and run locally. This is the default model type and there is
-    no setup needed to run this.
+    1. The 'local' type, where a model file is downloaded from HuggingFace and
+    run locally. This is the default model type and there is no setup needed to
+    run this.
+    The model (liwii/fluency-score-classification-ja) is a fine-tuned model
+    based on line-corporation/line-distilbert-base-japanese model.
     2. The 'openai' type, where we use OpenAI's 'gpt-turbo-3.5' model
     by default, in the same way as english counterpart. While the model you use
     is configurable, please make sure to use one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
     https://github.com/citadel-ai/langcheck#evaluate-text for examples on
     setting up the OpenAI API key.
+
+    Ref:
+        https://huggingface.co/line-corporation/line-distilbert-base-japanese
+        https://huggingface.co/liwii/fluency-score-classification-ja
 
     Args:
         generated_outputs: The model generated output(s) to evaluate

--- a/tests/eval/ja/test_reference_free_text_quality.py
+++ b/tests/eval/ja/test_reference_free_text_quality.py
@@ -68,21 +68,16 @@ def test_toxicity_openai(generated_outputs):
         assert eval_value.metric_values[0] == 1
 
 
-@pytest.mark.parametrize('generated_outputs',
-                         [
-                             ['ご機嫌いかがですか？私はとても元気です。',
-                              '機嫌いかが？私はとても元気人です。'
-                             ], ['猫'], '猫'
-                         ])
+@pytest.mark.parametrize(
+    'generated_outputs',
+    [['ご機嫌いかがですか？私はとても元気です。', '機嫌いかが？私はとても元気人です。'], ['猫'], '猫'])
 def test_fluency(generated_outputs):
     eval_value = fluency(generated_outputs)
     assert all(0 <= v <= 1 for v in eval_value.metric_values)
 
 
 @pytest.mark.parametrize('generated_outputs',
-                         ['ご機嫌いかがですか？私はとても元気です。',
-                          ['ご機嫌いかがですか？私はとても元気です。']
-                          ])
+                         ['ご機嫌いかがですか？私はとても元気です。', ['ご機嫌いかがですか？私はとても元気です。']])
 def test_fluency_openai(generated_outputs):
     mock_chat_response = {
         'choices': [{

--- a/tests/eval/ja/test_reference_free_text_quality.py
+++ b/tests/eval/ja/test_reference_free_text_quality.py
@@ -41,13 +41,14 @@ def test_sentiment_openai(generated_outputs):
         assert eval_value.metric_values[0] == 1
 
 
-@pytest.mark.parametrize('generated_outputs', [['馬鹿', '今日はりんごを食べました。'], ['猫']])
+@pytest.mark.parametrize('generated_outputs',
+                         [['馬鹿', '今日はりんごを食べました。'], ['猫'], '猫'])
 def test_toxicity(generated_outputs):
     eval_value = toxicity(generated_outputs)
     assert all(0 <= v <= 1 for v in eval_value.metric_values)
 
 
-@pytest.mark.parametrize('generated_outputs', ['アホ'])
+@pytest.mark.parametrize('generated_outputs', ['アホ', ['アホ']])
 def test_toxicity_openai(generated_outputs):
     mock_chat_response = {
         'choices': [{
@@ -68,13 +69,20 @@ def test_toxicity_openai(generated_outputs):
 
 
 @pytest.mark.parametrize('generated_outputs',
-                         [['ご機嫌いかがですか？私はとても元気です。', '機嫌いかが？私はとても元気人です。'], ['猫']])
+                         [
+                             ['ご機嫌いかがですか？私はとても元気です。',
+                              '機嫌いかが？私はとても元気人です。'
+                             ], ['猫'], '猫'
+                         ])
 def test_fluency(generated_outputs):
     eval_value = fluency(generated_outputs)
     assert all(0 <= v <= 1 for v in eval_value.metric_values)
 
 
-@pytest.mark.parametrize('generated_outputs', ['ご機嫌いかがですか？私はとても元気です。'])
+@pytest.mark.parametrize('generated_outputs',
+                         ['ご機嫌いかがですか？私はとても元気です。',
+                          ['ご機嫌いかがですか？私はとても元気です。']
+                          ])
 def test_fluency_openai(generated_outputs):
     mock_chat_response = {
         'choices': [{


### PR DESCRIPTION
Add `eval.ja.fluency()`

## Examples
```python
>>> import langcheck
>>> generated_outputs = [
...         '黒い猫が',
...         '黒い猫がいます',
...         'あっちの方で黒い猫があくびをしています',
...         'あっちの方でで黒い猫ががあくびをしています',
...         'ある日の暮方の事である。一人の下人が、羅生門の下で雨やみを待っていた。'
... ]
>>> langcheck.eval.ja.fluency(generated_outputs)
Metric: fluency
  prompt source                     generated_output reference_output  metric_value
0   None   None                                 黒い猫が             None      0.100664
1   None   None                              黒い猫がいます             None      0.241551
2   None   None                  あっちの方で黒い猫があくびをしています             None      0.563478
3   None   None                あっちの方でで黒い猫ががあくびをしています             None      0.045313
4   None   None  ある日の暮方の事である。一人の下人が、羅生門の下で雨やみを待っていた。             None      0.770122
```

## Sources
- Base model: https://huggingface.co/line-corporation/line-distilbert-base-japanese
- Fine-tuned model: https://huggingface.co/liwii/fluency-score-classification-ja
- Dataset: https://github.com/liwii/ja_perturbed

## TODO
- The performance is not good for short sentences even if there are no grammatical errors. Might need to improve in the future.