### PR TITLE
Fix MeCabTokenizer test

### DIFF
--- a/src/langcheck/eval/ja/_tokenizers.py
+++ b/src/langcheck/eval/ja/_tokenizers.py
@@ -62,8 +62,8 @@ class MeCabTokenizer(_JapaneseTokenizer):
         except ModuleNotFoundError:
             raise ModuleNotFoundError(
                 "No module named 'MeCab'.\n"
-                "Since 'MeCabTokenizer' is an optional feature, 'MeCab'"
-                "is not installed by default along with langcheck. Please"
+                "Since 'MeCabTokenizer' is an optional feature, 'MeCab' "
+                "is not installed by default along with langcheck. Please "
                 "set up 'MeCab' on your own.")
 
         self.tokenizer = MeCab.Tagger()

--- a/tests/eval/ja/test_tokenizers.py
+++ b/tests/eval/ja/test_tokenizers.py
@@ -1,4 +1,4 @@
-import sys
+import pkgutil
 from typing import List
 
 import pytest
@@ -21,7 +21,7 @@ def test_janome_tokenizer(text: str, expected_tokens: List[str],
     assert tokenizer.tokenize(text) == expected_tokens
 
 
-@pytest.mark.skipif("MeCab" in sys.modules,
+@pytest.mark.skipif(pkgutil.find_loader("MeCab"),
                     reason="MeCab has already been installed.")
 def test_handle_mecab_not_founud() -> None:
     with pytest.raises(ModuleNotFoundError):


### PR DESCRIPTION
Changes from @Alnusjaponica

`"MeCab" in sys.modules` couldn't detect the existence of the module properly, so `pytest.skipif` didn't work. This PR solves the problem.