### PR TITLE
Pin the PyTorch version in the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,9 @@
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.8-bullseye",
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install --upgrade pip && pip install yapf==0.40.1",
+	// PyTorch 2.1.0 causes segmentation fault in aarch64, so we pin the version in the dev container until the bug is fixed.
+	// Ref: https://github.com/pytorch/pytorch/issues/110819
+	"postCreateCommand": "pip install --upgrade pip && pip install yapf==0.40.1 && python -m pip install -e .[dev] && pip install torch==2.0.1",
 
 	"customizations": {
     // Configure properties specific to VS Code.


### PR DESCRIPTION
Ref: https://github.com/pytorch/pytorch/issues/110819

PyTorch 2.1.0 could cause segmentation fault in aarch64 devices. We pin the PyTorch version to 2.0.1 until the problem is fixed.