### PR TITLE
Add prompts parameter to all metric functions

### DIFF
--- a/src/langcheck/eval/_validation.py
+++ b/src/langcheck/eval/_validation.py
@@ -4,26 +4,29 @@ from typing import List, Optional
 
 
 def validate_parameters_reference_based(
-        generated_outputs: List[str] | str,
-        reference_outputs: List[str] | str) -> tuple[List[str], List[str]]:
+    generated_outputs: List[str] | str, reference_outputs: List[str] | str,
+    prompts: Optional[List[str] | str]
+) -> tuple[List[str], List[str], Optional[List[str]]]:
     '''Validates and parses function parameters for reference-based text quality
     metrics in langcheck.eval.
 
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
-        A tuple (generated_outputs, reference_outputs) of the parsed parameters.
-        All non-None parameters are converted to lists of strings.
+        A tuple (generated_outputs, reference_outputs, prompts) of the parsed
+        parameters. All non-None parameters are converted to lists of strings.
     '''
-    _generated_outputs, _, _reference_outputs, _ = _validate_parameters(
-        generated_outputs, None, reference_outputs, None)
+    _generated_outputs, _prompts, _reference_outputs, _ = _validate_parameters(
+        generated_outputs, prompts, reference_outputs, None)
 
     # For type checking
     assert isinstance(_reference_outputs, list)
 
-    return _generated_outputs, _reference_outputs
+    return _generated_outputs, _reference_outputs, _prompts
 
 
 def validate_parameters_reference_free(
@@ -34,7 +37,8 @@ def validate_parameters_reference_free(
 
     Args:
         generated_outputs: The model generated output(s) to evaluate
-        prompts: The prompt(s) used to generate the output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         A tuple (generated_outputs, prompts) of the parsed parameters. All
@@ -74,26 +78,29 @@ def validate_parameters_text_structure(
 
 
 def validate_parameters_source_based(
-        generated_outputs: List[str] | str,
-        sources: List[str] | str) -> tuple[List[str], List[str]]:
+    generated_outputs: List[str] | str, sources: List[str] | str,
+    prompts: Optional[List[str] | str]
+) -> tuple[List[str], List[str], Optional[List[str]]]:
     '''Validates and parses function parameters for source-based text quality
     metrics in langcheck.eval.
 
     Args:
         generated_outputs: The model generated output(s) to evaluate
         sources: The source(s) of the generated output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
-        A tuple (generated_outputs, sources) of the parsed parameters. All
-        non-None parameters are converted to lists of strings.
+        A tuple (generated_outputs, sources, prompts) of the parsed parameters.
+        All non-None parameters are converted to lists of strings.
     '''
-    _generated_outputs, _, _, _sources = _validate_parameters(
-        generated_outputs, None, None, sources)
+    _generated_outputs, _prompts, _, _sources = _validate_parameters(
+        generated_outputs, prompts, None, sources)
 
     # For type checking
     assert isinstance(_sources, list)
 
-    return _generated_outputs, _sources
+    return _generated_outputs, _sources, _prompts
 
 
 def _validate_parameters(
@@ -106,7 +113,8 @@ def _validate_parameters(
 
     Args:
         generated_outputs: The model generated output(s) to evaluate
-        prompts: The prompt(s) used to generate the output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
         reference_outputs: The reference output(s)
         sources: The source(s) of the generated output(s)
 
@@ -118,12 +126,12 @@ def _validate_parameters(
     # Convert single-string parameters to lists
     if isinstance(generated_outputs, str):
         generated_outputs = [generated_outputs]
+    if isinstance(prompts, str):
+        prompts = [prompts]
     if isinstance(reference_outputs, str):
         reference_outputs = [reference_outputs]
     if isinstance(sources, str):
         sources = [sources]
-    if isinstance(prompts, str):
-        prompts = [prompts]
 
     # Check that generated_outputs is not empty
     if not generated_outputs:

--- a/src/langcheck/eval/en/reference_based_text_quality.py
+++ b/src/langcheck/eval/en/reference_based_text_quality.py
@@ -103,7 +103,7 @@ def semantic_sim(generated_outputs: List[str] | str,
 
 def rouge1(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
-           prompts: Optional[List[str] | str]) -> EvalValue[float]:
+           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-1 scores between the generated
     outputs and the reference outputs. It evaluates the overlap of unigrams
     (single tokens) between the generated outputs and the reference outputs.
@@ -137,7 +137,7 @@ def rouge1(generated_outputs: List[str] | str,
 
 def rouge2(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
-           prompts: Optional[List[str] | str]) -> EvalValue[float]:
+           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-2 scores between the generated
     outputs and the reference outputs. It evaluates the overlap of bigrams
     (two adjacent tokens) between the generated outputs and the reference
@@ -170,7 +170,7 @@ def rouge2(generated_outputs: List[str] | str,
 
 def rougeL(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
-           prompts: Optional[List[str] | str]) -> EvalValue[float]:
+           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-L scores between the generated
     outputs and the reference outputs. It evaluates the longest common
     subsequence (LCS) between the generated outputs and the reference outputs.

--- a/src/langcheck/eval/en/reference_based_text_quality.py
+++ b/src/langcheck/eval/en/reference_based_text_quality.py
@@ -11,11 +11,12 @@ from langcheck.eval._validation import validate_parameters_reference_based
 from langcheck.eval.eval_value import EvalValue
 
 
-def semantic_sim(generated_outputs: List[str] | str,
-                 reference_outputs: List[str] | str,
-                 embedding_model_type: str = 'local',
-                 openai_args: Optional[Dict[str, str]] = None,
-                 prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
+def semantic_sim(
+        generated_outputs: List[str] | str,
+        reference_outputs: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
+        embedding_model_type: str = 'local',
+        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
     '''Calculates the semantic similarities between the generated outputs and
     the reference outputs. The similarities are computed as the cosine
     similarities between the generated and reference embeddings. This metric
@@ -43,12 +44,12 @@ def semantic_sim(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
         embedding_model_type: The type of embedding model to use ('local' or
             'openai'), default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.Embedding.create` function, default None
-        prompts: The prompts used to generate the output(s). Prompts are
-            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
@@ -150,7 +151,8 @@ def rouge2(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
-        prompts: The prompt(s) used to generate the output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object

--- a/src/langcheck/eval/en/reference_based_text_quality.py
+++ b/src/langcheck/eval/en/reference_based_text_quality.py
@@ -11,11 +11,11 @@ from langcheck.eval._validation import validate_parameters_reference_based
 from langcheck.eval.eval_value import EvalValue
 
 
-def semantic_sim(
-        generated_outputs: List[str] | str,
-        reference_outputs: List[str] | str,
-        embedding_model_type: str = 'local',
-        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
+def semantic_sim(generated_outputs: List[str] | str,
+                 reference_outputs: List[str] | str,
+                 embedding_model_type: str = 'local',
+                 openai_args: Optional[Dict[str, str]] = None,
+                 prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the semantic similarities between the generated outputs and
     the reference outputs. The similarities are computed as the cosine
     similarities between the generated and reference embeddings. This metric
@@ -47,12 +47,14 @@ def semantic_sim(
             'openai'), default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.Embedding.create` function, default None
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
     assert embedding_model_type in [
         'local', 'openai'
     ], ('Unsupported embedding model type. '
@@ -91,7 +93,7 @@ def semantic_sim(
     cosine_scores = torch.clamp(cosine_scores, -1.0, 1.0)
 
     return EvalValue(metric_name='semantic_sim',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,
@@ -100,7 +102,8 @@ def semantic_sim(
 
 
 def rouge1(generated_outputs: List[str] | str,
-           reference_outputs: List[str] | str) -> EvalValue[float]:
+           reference_outputs: List[str] | str,
+           prompts: Optional[List[str] | str]) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-1 scores between the generated
     outputs and the reference outputs. It evaluates the overlap of unigrams
     (single tokens) between the generated outputs and the reference outputs.
@@ -113,16 +116,18 @@ def rouge1(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs, reference_outputs, 'rouge1')
     return EvalValue(metric_name='rouge1',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,
@@ -131,7 +136,8 @@ def rouge1(generated_outputs: List[str] | str,
 
 
 def rouge2(generated_outputs: List[str] | str,
-           reference_outputs: List[str] | str) -> EvalValue[float]:
+           reference_outputs: List[str] | str,
+           prompts: Optional[List[str] | str]) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-2 scores between the generated
     outputs and the reference outputs. It evaluates the overlap of bigrams
     (two adjacent tokens) between the generated outputs and the reference
@@ -144,16 +150,17 @@ def rouge2(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompt(s) used to generate the output(s)
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs, reference_outputs, 'rouge2')
     return EvalValue(metric_name='rouge2',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,
@@ -162,7 +169,8 @@ def rouge2(generated_outputs: List[str] | str,
 
 
 def rougeL(generated_outputs: List[str] | str,
-           reference_outputs: List[str] | str) -> EvalValue[float]:
+           reference_outputs: List[str] | str,
+           prompts: Optional[List[str] | str]) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-L scores between the generated
     outputs and the reference outputs. It evaluates the longest common
     subsequence (LCS) between the generated outputs and the reference outputs.
@@ -175,12 +183,14 @@ def rougeL(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
 
     # The `rouge_score` package has two flavors of ROUGE-L [1]:
     # - 1) sentence-level, where newline characters are ignored
@@ -194,7 +204,7 @@ def rougeL(generated_outputs: List[str] | str,
     # [1] https://github.com/google-research/google-research/tree/master/rouge#two-flavors-of-rouge-l # NOQA E501
     scores = _rouge(generated_outputs, reference_outputs, 'rougeLsum')
     return EvalValue(metric_name='rougeL',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,

--- a/src/langcheck/eval/en/reference_based_text_quality.py
+++ b/src/langcheck/eval/en/reference_based_text_quality.py
@@ -53,7 +53,7 @@ def semantic_sim(generated_outputs: List[str] | str,
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
     assert embedding_model_type in [
         'local', 'openai'
@@ -122,7 +122,7 @@ def rouge1(generated_outputs: List[str] | str,
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs, reference_outputs, 'rouge1')
@@ -155,7 +155,7 @@ def rouge2(generated_outputs: List[str] | str,
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs, reference_outputs, 'rouge2')
@@ -189,7 +189,7 @@ def rougeL(generated_outputs: List[str] | str,
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
 
     # The `rouge_score` package has two flavors of ROUGE-L [1]:

--- a/src/langcheck/eval/en/source_based_text_quality.py
+++ b/src/langcheck/eval/en/source_based_text_quality.py
@@ -20,9 +20,9 @@ _factual_consistency_model = None
 def factual_consistency(
         generated_outputs: List[str] | str,
         sources: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
         model_type: str = 'local',
-        openai_args: Optional[Dict[str, str]] = None,
-        prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
+        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. The factual consistency score for one generated output is
     computed as the average of the per-sentence consistencies of the generated
@@ -48,12 +48,12 @@ def factual_consistency(
     Args:
         generated_outputs: The model generated output(s) to evaluate
         sources: The source text(s), one string per generated output
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
         model_type: The type of model to use ('local' or 'openai'),
             default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.ChatCompletion.create` function, default None
-        prompts: The prompts used to generate the output(s). Prompts are
-            optional metadata and not used to calculate the metric.
 
     Returns:
         An EvalValue object

--- a/src/langcheck/eval/en/source_based_text_quality.py
+++ b/src/langcheck/eval/en/source_based_text_quality.py
@@ -21,7 +21,8 @@ def factual_consistency(
         generated_outputs: List[str] | str,
         sources: List[str] | str,
         model_type: str = 'local',
-        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
+        openai_args: Optional[Dict[str, str]] = None,
+        prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. The factual consistency score for one generated output is
     computed as the average of the per-sentence consistencies of the generated
@@ -51,12 +52,14 @@ def factual_consistency(
             default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.ChatCompletion.create` function, default None
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An EvalValue object
     '''
-    generated_outputs, sources = validate_parameters_source_based(
-        generated_outputs, sources)
+    generated_outputs, sources, prompts = validate_parameters_source_based(
+        generated_outputs, sources, prompts)
     assert model_type in ['local', 'openai'
                          ], ('Unsupported model type. '
                              'The supported ones are ["local", "openai"]')
@@ -94,7 +97,7 @@ def factual_consistency(
         start_idx += num
 
     return EvalValue(metric_name='factual_consistency',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=None,
                      sources=sources,

--- a/src/langcheck/eval/ja/reference_based_text_quality.py
+++ b/src/langcheck/eval/ja/reference_based_text_quality.py
@@ -56,7 +56,7 @@ def semantic_sim(generated_outputs: List[str] | str,
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
     assert embedding_model_type in [
         'local', 'openai'
@@ -117,7 +117,7 @@ def rouge1(generated_outputs: List[str] | str,
     Returns:
         An EvalValue object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs,
@@ -156,7 +156,7 @@ def rouge2(generated_outputs: List[str] | str,
     Returns:
         An EvalValue object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs,
@@ -195,7 +195,7 @@ def rougeL(generated_outputs: List[str] | str,
     Returns:
         An EvalValue object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
 
     # The `rouge_score` package has two flavors of ROUGE-L [1]:

--- a/src/langcheck/eval/ja/reference_based_text_quality.py
+++ b/src/langcheck/eval/ja/reference_based_text_quality.py
@@ -14,11 +14,12 @@ from langcheck.eval.eval_value import EvalValue
 from langcheck.eval.ja._tokenizers import JanomeTokenizer
 
 
-def semantic_sim(generated_outputs: List[str] | str,
-                 reference_outputs: List[str] | str,
-                 embedding_model_type: str = 'local',
-                 openai_args: Optional[Dict[str, str]] = None,
-                 prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
+def semantic_sim(
+        generated_outputs: List[str] | str,
+        reference_outputs: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
+        embedding_model_type: str = 'local',
+        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
     '''Calculates the semantic similarities between the generated outputs and
     the reference outputs. The similarities are computed as the cosine
     similarities between the generated and reference embeddings. This metric
@@ -46,12 +47,12 @@ def semantic_sim(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
         embedding_model_type: The type of embedding model to use ('local' or
             'openai'), default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.Embedding.create` function, default None
-        prompts: The prompts used to generate the output(s). Prompts are
-            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
@@ -67,7 +68,7 @@ def semantic_sim(generated_outputs: List[str] | str,
         # We can use the same API as english semantic_sim to compare the
         # similarity
         eval_value = en_semantic_sim(generated_outputs, reference_outputs,
-                                     embedding_model_type, openai_args)
+                                     prompts, embedding_model_type, openai_args)
         eval_value.language = 'ja'
         return eval_value
 
@@ -97,9 +98,9 @@ def semantic_sim(generated_outputs: List[str] | str,
 
 def rouge1(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
+           prompts: Optional[List[str] | str] = None,
            *,
-           tokenizer: Optional[Tokenizer] = None,
-           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
+           tokenizer: Optional[Tokenizer] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-1 scores between the generated
     (single tokens) between the generated outputs and the reference outputs.
     This metric takes on float values between [0, 1], where 0 is no overlap and
@@ -135,9 +136,9 @@ def rouge1(generated_outputs: List[str] | str,
 
 def rouge2(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
+           prompts: Optional[List[str] | str] = None,
            *,
-           tokenizer: Optional[Tokenizer] = None,
-           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
+           tokenizer: Optional[Tokenizer] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-2 scores between the generated
     outputs and the reference outputs. It evaluates the overlap of bigrams
     (two adjacent tokens) between the generated outputs and the reference
@@ -174,9 +175,9 @@ def rouge2(generated_outputs: List[str] | str,
 
 def rougeL(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
+           prompts: Optional[List[str] | str] = None,
            *,
-           tokenizer: Optional[Tokenizer] = None,
-           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
+           tokenizer: Optional[Tokenizer] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-L scores between the generated
     outputs and the reference outputs. It evaluates the longest common
     subsequence (LCS) between the generated outputs and the reference outputs.

--- a/src/langcheck/eval/ja/reference_based_text_quality.py
+++ b/src/langcheck/eval/ja/reference_based_text_quality.py
@@ -14,11 +14,11 @@ from langcheck.eval.eval_value import EvalValue
 from langcheck.eval.ja._tokenizers import JanomeTokenizer
 
 
-def semantic_sim(
-        generated_outputs: List[str] | str,
-        reference_outputs: List[str] | str,
-        embedding_model_type: str = 'local',
-        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
+def semantic_sim(generated_outputs: List[str] | str,
+                 reference_outputs: List[str] | str,
+                 embedding_model_type: str = 'local',
+                 openai_args: Optional[Dict[str, str]] = None,
+                 prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the semantic similarities between the generated outputs and
     the reference outputs. The similarities are computed as the cosine
     similarities between the generated and reference embeddings. This metric
@@ -50,12 +50,14 @@ def semantic_sim(
             'openai'), default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.Embedding.create` function, default None
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
     assert embedding_model_type in [
         'local', 'openai'
     ], ('Unsupported embedding model type. '
@@ -85,7 +87,7 @@ def semantic_sim(
     cosine_scores = torch.clamp(cosine_scores, -1.0, 1.0)
 
     return EvalValue(metric_name='semantic_sim',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,
@@ -96,7 +98,8 @@ def semantic_sim(
 def rouge1(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
            *,
-           tokenizer: Optional[Tokenizer] = None) -> EvalValue[float]:
+           tokenizer: Optional[Tokenizer] = None,
+           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-1 scores between the generated
     (single tokens) between the generated outputs and the reference outputs.
     This metric takes on float values between [0, 1], where 0 is no overlap and
@@ -108,19 +111,21 @@ def rouge1(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An EvalValue object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs,
                     reference_outputs,
                     'rouge1',
                     tokenizer=tokenizer)
     return EvalValue(metric_name='rouge1',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,
@@ -131,7 +136,8 @@ def rouge1(generated_outputs: List[str] | str,
 def rouge2(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
            *,
-           tokenizer: Optional[Tokenizer] = None) -> EvalValue[float]:
+           tokenizer: Optional[Tokenizer] = None,
+           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-2 scores between the generated
     outputs and the reference outputs. It evaluates the overlap of bigrams
     (two adjacent tokens) between the generated outputs and the reference
@@ -144,19 +150,21 @@ def rouge2(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An EvalValue object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
 
     scores = _rouge(generated_outputs,
                     reference_outputs,
                     'rouge2',
                     tokenizer=tokenizer)
     return EvalValue(metric_name='rouge2',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,
@@ -167,7 +175,8 @@ def rouge2(generated_outputs: List[str] | str,
 def rougeL(generated_outputs: List[str] | str,
            reference_outputs: List[str] | str,
            *,
-           tokenizer: Optional[Tokenizer] = None) -> EvalValue[float]:
+           tokenizer: Optional[Tokenizer] = None,
+           prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the F1 metrics of the ROUGE-L scores between the generated
     outputs and the reference outputs. It evaluates the longest common
     subsequence (LCS) between the generated outputs and the reference outputs.
@@ -180,12 +189,14 @@ def rougeL(generated_outputs: List[str] | str,
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An EvalValue object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
 
     # The `rouge_score` package has two flavors of ROUGE-L [1]:
     # - 1) sentence-level, where newline characters are ignored
@@ -202,7 +213,7 @@ def rougeL(generated_outputs: List[str] | str,
                     'rougeLsum',
                     tokenizer=tokenizer)
     return EvalValue(metric_name='rougeL',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,

--- a/src/langcheck/eval/ja/source_based_text_quality.py
+++ b/src/langcheck/eval/ja/source_based_text_quality.py
@@ -17,7 +17,8 @@ def factual_consistency(
         generated_outputs: List[str] | str,
         sources: List[str] | str,
         model_type: str = 'local',
-        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
+        openai_args: Optional[Dict[str, str]] = None,
+        prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. The factual consistency score for one generated output is
     computed as the average of the per-sentence consistencies of the generated
@@ -52,12 +53,14 @@ def factual_consistency(
             default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.ChatCompletion.create` function, default None
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An EvalValue object
     '''
-    generated_outputs, sources = validate_parameters_source_based(
-        generated_outputs, sources)
+    generated_outputs, sources, prompts = validate_parameters_source_based(
+        generated_outputs, sources, prompts)
     assert model_type in ['local', 'openai'
                          ], ('Unsupported model type. '
                              'The supported ones are ["local", "openai"]')
@@ -89,7 +92,7 @@ def factual_consistency(
         generated_outputs=en_generated_outputs, sources=en_source).metric_values
 
     return EvalValue(metric_name='factual_consistency',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=None,
                      sources=sources,

--- a/src/langcheck/eval/ja/source_based_text_quality.py
+++ b/src/langcheck/eval/ja/source_based_text_quality.py
@@ -16,9 +16,9 @@ _factual_consistency_translation_pipeline = None
 def factual_consistency(
         generated_outputs: List[str] | str,
         sources: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
         model_type: str = 'local',
-        openai_args: Optional[Dict[str, str]] = None,
-        prompts: Optional[List[str] | str] = None) -> EvalValue[float]:
+        openai_args: Optional[Dict[str, str]] = None) -> EvalValue[float]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. The factual consistency score for one generated output is
     computed as the average of the per-sentence consistencies of the generated
@@ -49,12 +49,12 @@ def factual_consistency(
     Args:
         generated_outputs: The model generated output(s) to evaluate
         sources: The source text(s), one string per generated output
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
         model_type: The type of model to use ('local' or 'openai'),
             default 'local'
         openai_args: Dict of additional args to pass in to the
             `openai.ChatCompletion.create` function, default None
-        prompts: The prompts used to generate the output(s). Prompts are
-            optional metadata and not used to calculate the metric.
 
     Returns:
         An EvalValue object
@@ -68,7 +68,7 @@ def factual_consistency(
     # The English prompt works well enough for Japanese
     # TODO: Investigate the performance improvement with Japanese prompt
     if model_type == 'openai':
-        eval_value = en_factual_consistency(generated_outputs, sources,
+        eval_value = en_factual_consistency(generated_outputs, sources, prompts,
                                             model_type, openai_args)
         eval_value.language = 'ja'
         return eval_value

--- a/src/langcheck/eval/reference_based_text_quality.py
+++ b/src/langcheck/eval/reference_based_text_quality.py
@@ -21,7 +21,7 @@ def exact_match(generated_outputs: List[str] | str,
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(  # NOQA E501
         generated_outputs, reference_outputs, prompts)
 
     # The values are binary: 1 if it's an exact match and 0 if not

--- a/src/langcheck/eval/reference_based_text_quality.py
+++ b/src/langcheck/eval/reference_based_text_quality.py
@@ -1,25 +1,28 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from langcheck.eval._validation import validate_parameters_reference_based
 from langcheck.eval.eval_value import EvalValue
 
 
 def exact_match(generated_outputs: List[str] | str,
-                reference_outputs: List[str] | str) -> EvalValue[int]:
+                reference_outputs: List[str] | str,
+                prompts: Optional[List[str] | str] = None) -> EvalValue[int]:
     '''Checks if the generated outputs exact matches with the reference outputs.
     This metric takes on binary 0 or 1 values.
 
     Args:
         generated_outputs: The model generated output(s) to evaluate
         reference_outputs: The reference output(s)
+        prompts: The prompts used to generate the output(s). Prompts are
+            optional metadata and not used to calculate the metric.
 
     Returns:
         An :class:`~langcheck.eval.eval_value.EvalValue` object
     '''
-    generated_outputs, reference_outputs = validate_parameters_reference_based(
-        generated_outputs, reference_outputs)
+    generated_outputs, reference_outputs, prompts = validate_parameters_reference_based(
+        generated_outputs, reference_outputs, prompts)
 
     # The values are binary: 1 if it's an exact match and 0 if not
     metric_values = []
@@ -30,7 +33,7 @@ def exact_match(generated_outputs: List[str] | str,
             metric_values.append(0)
 
     return EvalValue(metric_name='exact_match',
-                     prompts=None,
+                     prompts=prompts,
                      generated_outputs=generated_outputs,
                      reference_outputs=reference_outputs,
                      sources=None,


### PR DESCRIPTION
Resolves #7. Some functions were missing the optional `prompts` parameter. 