### PR TITLE
Update VSCode settings for formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
 		"ms-python.vscode-pylance",
 		"ms-python.flake8",
 		"ms-python.isort",
+		"eeyore.yapf",
 		"GitHub.vscode-pull-request-github",
 		"ms-azuretools.vscode-docker",
 		"shardulm94.trailing-spaces",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,12 @@
 {
-  "python.formatting.provider": "yapf",
+  // Settings from https://marketplace.visualstudio.com/items?itemName=eeyore.yapf
+  "python.formatting.provider": "none",
   "[python]": {
     "editor.codeActionsOnSave": {
       "source.organizeImports": true
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSaveMode": "file",
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "eeyore.yapf"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  // Settings from https://marketplace.visualstudio.com/items?itemName=eeyore.yapf
   "python.formatting.provider": "none",
   "[python]": {
     "editor.codeActionsOnSave": {


### PR DESCRIPTION
`"python.formatting.provider": "yapf"` is deprecated, so updated the VSCode settings following https://marketplace.visualstudio.com/items?itemName=eeyore.yapf to re-enable auto-formatting.