### PR TITLE
Update the translation model

### DIFF
--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -9,7 +9,7 @@ from langcheck.metrics.en.source_based_text_quality import \
     factual_consistency as en_factual_consistency
 from langcheck.metrics.metric_value import MetricValue
 
-_factual_consistency_translation_model_path = 'staka/fugumt-ja-en'
+_factual_consistency_translation_model_path = 'Helsinki-NLP/opus-mt-ja-en'
 _factual_consistency_translation_pipeline = None
 
 
@@ -34,7 +34,7 @@ def factual_consistency(
     from HuggingFace and run locally. This is the default model type and
     there is no setup needed to run this.
     This function wraps :func:`~langcheck.metrics.en.en_factual_consistency`
-    using the translation model ``staka/fugumt-ja-en`` to translate the
+    using the translation model ``Helsinki-NLP/opus-mt-ja-en`` to translate the
     Japanese texts to English before computing the factual consistency
     scores. This is because the UniEval-fact model is trained on English
     text.


### PR DESCRIPTION
Updated the translation model used for Japanese factual consistency to the one with apache-2.0 license.

Ref: https://huggingface.co/Helsinki-NLP/opus-mt-ja-en/tree/main