### PR TITLE
Fix docs warning

### DIFF
--- a/src/langcheck/metrics/en/reference_based_text_quality.py
+++ b/src/langcheck/metrics/en/reference_based_text_quality.py
@@ -33,8 +33,8 @@ def semantic_similarity(
 
     2. The 'openai' type, where we use OpenAI's 'text-embedding-ada-002' model
     by default (this is configurable). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     on setting up the OpenAI API key.
 
     Ref:

--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -45,8 +45,8 @@ def sentiment(
     by default. While the model you use is configurable, please make sure to use
     one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Args:
@@ -201,8 +201,8 @@ def fluency(
     by default. While the model you use is configurable, please make sure to use
     one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Args:
@@ -357,8 +357,8 @@ def toxicity(
     by default. While the model you use is configurable, please make sure to use
     one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Args:

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -44,8 +44,8 @@ def factual_consistency(
     by default. While the model you use is configurable, please make sure to use
     one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Args:

--- a/src/langcheck/metrics/ja/reference_based_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_based_text_quality.py
@@ -36,8 +36,8 @@ def semantic_similarity(
 
     2. The 'openai' type, where we use OpenAI's 'text-embedding-ada-002' model
     by default (this is configurable). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Ref:

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -49,8 +49,8 @@ def sentiment(
     by default. While the model you use is configurable, please make sure to use
     one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Ref:
@@ -136,8 +136,8 @@ def toxicity(
     by default, in the same way as english counterpart. While the model you use
     is configurable, please make sure to use one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Ref:
@@ -231,8 +231,8 @@ def fluency(
     by default, in the same way as english counterpart. While the model you use
     is configurable, please make sure to use one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Ref:

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -45,8 +45,8 @@ def factual_consistency(
     by default. While the model you use is configurable, please make sure to use
     one that supports function calling
     (https://platform.openai.com/docs/guides/gpt/function-calling). See
-    `this example
-    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`_
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Args:


### PR DESCRIPTION
## Motivation
Follow-up https://github.com/citadel-ai/langcheck/pull/23

Currently, we have following error when building docs:
```
...
docstring of langcheck.metrics.en.reference_free_text_quality.fluency:7: ERROR: Unknown target name: "this example https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>".
...
```
and this PR fixes them.