### PR TITLE
[HOT FIX] Pin `openai<1.0.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     'janome >= 0.3.1',
     "nlpaug",
     'nltk >= 3',
-    'openai >= 0.11.6',
+    'openai >= 0.11.6, <1',
     'pandas >= 1',
     'plotly >= 5',
     'rouge_score >= 0.1.2',


### PR DESCRIPTION
## Motivation 
Some breaking changes are introduced by the major update of `opneai`, which currently prevents irrelevant PR from merging. This PR pins the version to temporary resolve the CI failure. 