### PR TITLE
Constraint `tokenizers` version for python >=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     'sentence_transformers >= 2',
     'sentencepiece>=0.1.95',
     'tomli; python_version < "3.11"',
+    'tokenizers >= 0.13.2; python_version >= "3.11"',
     'torch >= 2',
     'transformers >= 4.6',
     "unidic-lite >= 1.0.1"  # For tokenizer of metrics.ja.toxicity()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     'sentence_transformers >= 2',
     'sentencepiece>=0.1.95',
     'tomli; python_version < "3.11"',
-    'tokenizers >= 0.13.2; python_version >= "3.11"',
+    'tokenizers >= 0.13.2; python_version >= "3.11"',  # See https://github.com/citadel-ai/langcheck/pull/45
     'torch >= 2',
     'transformers >= 4.6',
     "unidic-lite >= 1.0.1"  # For tokenizer of metrics.ja.toxicity()


### PR DESCRIPTION
The `tokenizers` package first officially added support for Python 3.11 in the [0.13.2 release](https://github.com/huggingface/tokenizers/releases/tag/python-v0.13.2). While it's technically possible to build `tokenizers` from source (although this requires users to have a rust compiler), we found that this fails on x86. So, we add the constraint that `tokenizers >= 0.13.2` for Python 3.11 and above.