### PR TITLE
Rename eval_value to metric_value in documentation

### DIFF
--- a/docs/langcheck.metrics.ja.rst
+++ b/docs/langcheck.metrics.ja.rst
@@ -18,3 +18,4 @@ langcheck.metrics.ja
 
    langcheck.metrics.ja.reference_based_text_quality
    langcheck.metrics.ja.reference_free_text_quality
+   langcheck.metrics.ja.source_based_text_quality

--- a/docs/langcheck.metrics.ja.source_based_text_quality.rst
+++ b/docs/langcheck.metrics.ja.source_based_text_quality.rst
@@ -1,0 +1,8 @@
+
+langcheck.metrics.ja.source\_based\_text\_quality
+=================================================
+
+.. automodule:: langcheck.metrics.ja.source_based_text_quality
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.metric_value.rst
+++ b/docs/langcheck.metrics.metric_value.rst
@@ -1,6 +1,6 @@
 
-langcheck.metrics.eval\_value
-=============================
+langcheck.metrics.metric\_value
+===============================
 
 .. automodule:: langcheck.metrics.metric_value
    :members:


### PR DESCRIPTION
I reran `sphinx-apidoc -f --no-toc --separate --module-first -t docs/_templates/ -o docs src/langcheck/ src/langcheck/stats.py` to update the documentation to the latest package hierarchy and names. 