### PR TITLE
OpenAI-based rephrasing

### DIFF
--- a/src/langcheck/augment/__init__.py
+++ b/src/langcheck/augment/__init__.py
@@ -1,8 +1,8 @@
 from langcheck.augment import en
 from langcheck.augment.en import (change_case, keyboard_typo, ocr_typo,
-                                  remove_punctuation, synonym)
+                                  remove_punctuation, rephrase, synonym)
 
 __all__ = [
     "en", "keyboard_typo", "ocr_typo", "synonym", "change_case",
-    "remove_punctuation"
+    "remove_punctuation", "rephrase"
 ]

--- a/src/langcheck/augment/en/__init__.py
+++ b/src/langcheck/augment/en/__init__.py
@@ -2,8 +2,10 @@ from langcheck.augment.en._change_case import change_case
 from langcheck.augment.en._keyboard_typo import keyboard_typo
 from langcheck.augment.en._ocr_typo import ocr_typo
 from langcheck.augment.en._remove_punctuation import remove_punctuation
+from langcheck.augment.en._rephrase import rephrase
 from langcheck.augment.en._synonym import synonym
 
 __all__ = [
-    'change_case', 'keyboard_typo', 'ocr_typo', 'synonym', 'remove_punctuation'
+    'change_case', 'keyboard_typo', 'ocr_typo', 'synonym', 'remove_punctuation',
+    'rephrase'
 ]

--- a/src/langcheck/augment/en/_rephrase.py
+++ b/src/langcheck/augment/en/_rephrase.py
@@ -8,14 +8,14 @@ import openai
 def rephrase(
         instances: list[str] | str,
         openai_args: Optional[dict[str, str]] = None) -> list[Optional[str]]:
-    '''Rephrase each string in instances (usually a list of prompts) without
-    changintg the meanings. We use the modified version of a prompt presented
-    in `Rethinking Benchmark and Contamination for Language Models with
-    Rephrased Samples <https://arxiv.org/abs/2311.04850>`__ to make an LLM
-    rephrase the given texts.  Currently only OpenAI-based is supported.
-    We use OpenAI's 'gpt-turbo-3.5' model by default. See
-    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
-    #computing-metrics-with-openai-models>`__
+    '''Rephrases each string in instances (usually a list of prompts) without
+    changing their meaning. We use a modified version of the prompt presented
+    in `"Rethinking Benchmark and Contamination for Language Models with
+    Rephrased Samples" <https://arxiv.org/abs/2311.04850>`__ to make an LLM
+    rephrase the given text.
+    Currently, this is not available locally and requires an OpenAI API key,
+    using the 'gpt-turbo-3.5' model by default. See `this page
+    <https://langcheck.readthedocs.io/en/latest/metrics.html#computing-metrics-with-openai-models>`__
     for examples on setting up the OpenAI API key.
 
     Args:

--- a/src/langcheck/augment/en/_rephrase.py
+++ b/src/langcheck/augment/en/_rephrase.py
@@ -28,8 +28,8 @@ def rephrase(
 
     2. The 'azure_openai' type. Essentially the same as the 'openai' type,
     except that it uses the AzureOpenAI client. Note that you must specify the
-    model to use in `openai_args`, e.g.
-    `openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}`
+    model to use in ``openai_args``, e.g.
+    ``openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}``
 
     Args:
         instances: A single string or a list of strings to be augmented.
@@ -40,7 +40,7 @@ def rephrase(
         openai_client: OpenAI or AzureOpenAI client, default None. If this is
             None, we will attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
-            `client.chat.completions.create` function, default None
+            ``client.chat.completions.create`` function, default None
 
     Returns:
         A list of rephrased instances.

--- a/src/langcheck/augment/en/_rephrase.py
+++ b/src/langcheck/augment/en/_rephrase.py
@@ -80,14 +80,17 @@ def rephrase(
             [END DATA]
             '''
             messages = [{"role": "user", "content": prompt}]
+            chat_completions = openai_client.chat.completions
             try:
                 if openai_args is None:
-                    response = openai_client.chat.completions.create(
-                        model="gpt-3.5-turbo", messages=messages)
+                    response = chat_completions.create(
+                        model="gpt-3.5-turbo",
+                        messages=messages  # type: ignore
+                    )
                 else:
-                    response = openai_client.chat.completions.create(
-                        messages=messages,
-                        **openai_args,
+                    response = chat_completions.create(  # type: ignore
+                        messages=messages,  # type: ignore
+                        **openai_args,  # type: ignore
                     )
                 rephrased_instance = response.choices[0].message.content
                 rephrased_instances.append(rephrased_instance)

--- a/src/langcheck/augment/en/_rephrase.py
+++ b/src/langcheck/augment/en/_rephrase.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import openai
+
+
+def rephrase(
+        instances: list[str] | str,
+        openai_args: Optional[dict[str, str]] = None) -> list[Optional[str]]:
+    '''Rephrase each string in instances (usually a list of prompts) without
+    changintg the meanings. We use the modified version of a prompt presented
+    in `Rethinking Benchmark and Contamination for Language Models with
+    Rephrased Samples <https://arxiv.org/abs/2311.04850>`__ to make an LLM
+    rephrase the given texts.  Currently only OpenAI-based is supported.
+    We use OpenAI's 'gpt-turbo-3.5' model by default. See
+    `this example <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
+    for examples on setting up the OpenAI API key.
+
+    Args:
+        instances: A single string or a list of strings to be augmented.
+        openai_args: Dict of additional args to pass in to the
+            `openai.ChatCompletion.create` function, default None
+
+    Returns:
+        A list of rephrased instances.
+    '''
+    instances = [instances] if isinstance(instances, str) else instances
+    rephrased_instances = []
+    for instance in instances:
+        prompt = f'''
+        Please rephrase the following prompt without altering its meaning,
+        ensuring you adjust the word order appropriately.
+        Ensure that no more than five consecutive words are repeated
+        and try to use similar words as substitutes where possible.
+        [BEGIN DATA]
+        ************
+        [Prompt]: {instance}
+        ************
+        [END DATA]
+        '''
+        messages = [{"role": "user", "content": prompt}]
+        try:
+            if openai_args is None:
+                response = openai.ChatCompletion.create(
+                    model="gpt-3.5-turbo",
+                    messages=messages,
+                )
+            else:
+                response = openai.ChatCompletion.create(
+                    messages=messages,
+                    **openai_args,
+                )
+            # This metrics-with-openai-models>`__ is necessary to pass pyright
+            # since the openai library is not typed.
+            assert isinstance(response, dict)
+            rephrased_instance = response["choices"][0]["message"]["content"]
+            rephrased_instances.append(rephrased_instance)
+        except Exception as e:
+            print(f'OpenAI failed to return a rephrased prompt: {e}')
+            print(f'Prompt that triggered the failure is:\n{prompt}')
+            rephrased_instances.append(None)
+
+    return rephrased_instances

--- a/tests/augment/test_rephrase.py
+++ b/tests/augment/test_rephrase.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from langcheck.augment.en import rephrase
+
+
+@pytest.mark.parametrize(
+    "instances, expected",
+    [
+        ("List three representative testing methods for LLMs.",
+         ["Identify three typical methods used for evaluating LLMs."]),
+        (["List three representative testing methods for LLMs."
+         ], ["Identify three typical methods used for evaluating LLMs."]),
+    ],
+)
+def test_rephrase(instances: list[str] | str, expected: list[str]):
+    mock_chat_response = {
+        'choices': [{
+            'message': {
+                'content':
+                    'Identify three typical methods used for evaluating LLMs.'
+            }
+        }]
+    }
+    # Calling the openai.ChatCompletion.create method requires an OpenAI API
+    # key, so we mock the return value instead
+    with patch('openai.ChatCompletion.create',
+               Mock(return_value=mock_chat_response)):
+        actual = rephrase(instances)
+        assert actual == expected

--- a/tests/augment/test_rephrase.py
+++ b/tests/augment/test_rephrase.py
@@ -1,33 +1,47 @@
 from __future__ import annotations
 
+import os
 from unittest.mock import Mock, patch
 
 import pytest
+from openai.types.chat import ChatCompletion
 
 from langcheck.augment.en import rephrase
 
 
 @pytest.mark.parametrize(
-    "instances, expected",
+    "instances, num_perturbations, expected",
     [
-        ("List three representative testing methods for LLMs.",
+        ("List three representative testing methods for LLMs.", 1,
          ["Identify three typical methods used for evaluating LLMs."]),
-        (["List three representative testing methods for LLMs."
-         ], ["Identify three typical methods used for evaluating LLMs."]),
+        (["List three representative testing methods for LLMs."], 2, [
+            "Identify three typical methods used for evaluating LLMs.",
+            "Identify three typical methods used for evaluating LLMs."
+        ]),
     ],
 )
-def test_rephrase(instances: list[str] | str, expected: list[str]):
-    mock_chat_response = {
-        'choices': [{
-            'message': {
-                'content':
-                    'Identify three typical methods used for evaluating LLMs.'
-            }
-        }]
-    }
+def test_rephrase(instances: list[str] | str, num_perturbations: int,
+                  expected: list[str]):
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(
+            content='Identify three typical methods used for evaluating LLMs.'))
+    ]
     # Calling the openai.ChatCompletion.create method requires an OpenAI API
     # key, so we mock the return value instead
-    with patch('openai.ChatCompletion.create',
-               Mock(return_value=mock_chat_response)):
-        actual = rephrase(instances)
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        actual = rephrase(instances, num_perturbations=num_perturbations)
+        assert actual == expected
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        actual = rephrase(instances,
+                          num_perturbations=num_perturbations,
+                          model_type='azure_openai',
+                          openai_args={'model': 'foo bar'})
         assert actual == expected


### PR DESCRIPTION
Implemented `langcheck.augment.rephrase`, which does OpenAI-based paraphrasing of the given prompts.

Here are some examples with prompts picked from https://growthtribe.io/blog/chatgpt-prompts.

```
>>> langcheck.augment.rephrase('Solve this math problem for me and explain any jargon.', openai_args={'engine': 'gpt-35-function-calling'})
['Can you solve this math problem and clarify any technical terminology for me?']
>>> langcheck.augment.rephrase('I’m visiting Japan for two weeks, name three cities I should visit that includes fun, culture and romance.', openai_args={'engine': 'gpt-35-function-calling'})
['Name three cities in Japan that I should visit for two weeks, incorporating fun, culture, and romance.']
```