### PR TITLE
OpenAI (sort of) reproducible outputs

### DIFF
--- a/src/langcheck/augment/en/_rephrase.py
+++ b/src/langcheck/augment/en/_rephrase.py
@@ -67,7 +67,7 @@ def rephrase(
     instances = [instances] if isinstance(instances, str) else instances
     rephrased_instances = []
     for instance in instances:
-        for _ in range(num_perturbations):
+        for i in range(num_perturbations):
             prompt = f'''
             Please rephrase the following prompt without altering its meaning,
             ensuring you adjust the word order appropriately.
@@ -85,11 +85,12 @@ def rephrase(
                 if openai_args is None:
                     response = chat_completions.create(
                         model="gpt-3.5-turbo",
-                        messages=messages  # type: ignore
-                    )
+                        messages=messages,  # type: ignore
+                        seed=i)
                 else:
                     response = chat_completions.create(  # type: ignore
                         messages=messages,  # type: ignore
+                        seed=i,
                         **openai_args,  # type: ignore
                     )
                 rephrased_instance = response.choices[0].message.content

--- a/src/langcheck/metrics/en/_openai.py
+++ b/src/langcheck/metrics/en/_openai.py
@@ -94,10 +94,13 @@ class OpenAIBasedEvaluator:
         try:
             if self._openai_args is None:
                 response = self._client.chat.completions.create(
-                    model="gpt-3.5-turbo", messages=messages)  # type: ignore
+                    model="gpt-3.5-turbo", seed=123,
+                    messages=messages)  # type: ignore
             else:
                 response = self._client.chat.completions.create(
-                    messages=messages, **self._openai_args)  # type: ignore
+                    messages=messages,  # type: ignore
+                    seed=123,
+                    **self._openai_args)  # type: ignore
             unstructured_assessment = response.choices[0].message.content
         except Exception as e:
             print(f'OpenAI failed to return an unstructured assessment: {e}')
@@ -131,11 +134,13 @@ class OpenAIBasedEvaluator:
                 response = self._client.chat.completions.create(
                     model="gpt-3.5-turbo",
                     messages=fn_call_messages,  # type: ignore
+                    seed=123,
                     functions=functions,  # type: ignore
                     function_call={"name": self._function_name})
             else:
                 response = self._client.chat.completions.create(  # type: ignore
                     messages=fn_call_messages,  # type: ignore
+                    seed=123,
                     functions=functions,  # type: ignore
                     function_call={"name": self._function_name},
                     **self._openai_args)  # type: ignore


### PR DESCRIPTION
Following https://cookbook.openai.com/examples/deterministic_outputs_with_the_seed_parameter, we now set the `seed` parameter to make the evaluation results and generated rephrases more deterministic.

Unfortunately, setting the seed doesn't actually guarantee anything, and it's more of a best effort to reproduce the same outputs. Still, it's better than nothing!
<img width="796" alt="image" src="https://github.com/citadel-ai/langcheck/assets/107823399/2b06eb76-7506-469f-accd-0915e548ef7f">
