### PR TITLE
add prototype model manager

### DIFF
--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -18,6 +18,7 @@ _model_manager = ModelConfig()
 reset_model_config = _model_manager.reset
 set_model_for_metric = _model_manager.set_model_for_metric
 list_metric_model = _model_manager.list_metric_model
+get_metric_model = _model_manager.get_metric_model
 load_config_from_file = _model_manager.load_config_from_file
 save_config_to_disk = _model_manager.save_config_to_disk
 
@@ -51,5 +52,6 @@ __all__ = [
     'list_metric_model',
     'load_config_from_file',
     'save_config_to_disk',
-    'reset_model_config'
+    'reset_model_config',
+    'get_metric_model'
 ]

--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -1,5 +1,5 @@
-from langcheck.metrics._model_management import ModelConfig
 from langcheck.metrics import en, ja, zh
+from langcheck.metrics._model_management import ModelConfig
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.en.reference_free_text_quality import (

--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -1,3 +1,4 @@
+from langcheck.metrics._model_management import ModelConfig
 from langcheck.metrics import en, ja, zh
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
@@ -12,6 +13,13 @@ from langcheck.metrics.text_structure import (contains_all_strings,
                                               contains_regex, is_float, is_int,
                                               is_json_array, is_json_object,
                                               matches_regex, validation_fn)
+
+_model_manager = ModelConfig()
+reset_model_config = _model_manager.reset
+set_model_for_metric = _model_manager.set_model_for_metric
+list_metric_model = _model_manager.list_metric_model
+load_config_from_file = _model_manager.load_config_from_file
+save_config_to_disk = _model_manager.save_config_to_disk
 
 __all__ = [
     'en',
@@ -39,4 +47,9 @@ __all__ = [
     'semantic_similarity',
     'sentiment',
     'toxicity',
+    'set_model_for_metric',
+    'list_metric_model',
+    'load_config_from_file',
+    'save_config_to_disk',
+    'reset_model_config'
 ]

--- a/src/langcheck/metrics/_model_management.py
+++ b/src/langcheck/metrics/_model_management.py
@@ -1,6 +1,6 @@
-import os
 import collections
 import configparser
+import os
 from pathlib import Path
 
 
@@ -52,8 +52,8 @@ class ModelConfig:
                 print(self.model_config[language][metric_type])
             else:
                 raise KeyError(
-                    f"Model type '{metric_type}' not found for language '{language}'."
-                )  # NOQA:E501
+                    f"Model type '{metric_type}' not found for language '{language}'."  # NOQA:E501
+                )
         else:
             raise KeyError(f"Language '{language}' not supported.")
 

--- a/src/langcheck/metrics/_model_management.py
+++ b/src/langcheck/metrics/_model_management.py
@@ -1,0 +1,111 @@
+import os
+import configparser
+import collections
+from pathlib import Path
+
+
+class ModelConfig:
+    """
+    A class to manage different models for multiple languages in the
+    langcheck.
+    This class allows setting and retrieving different model names.
+    (like sentiment_model, semantic_similarity_model, etc.) for each language.
+    It also supports loading model configurations from a file.
+    """
+
+    def __init__(self):
+        """
+        Initializes the ModelConfig with empty model dictionaries for each
+        language.
+        """
+        self.__init__config()
+
+    def __init__config(self):
+        cwd = os.path.dirname(__file__)
+        cfg = configparser.ConfigParser()
+        # Initial DEFAULT config from modelconfig.ini
+        cfg.read(os.path.join(Path(cwd), 'modelconfig.ini'))
+        self.model_config = collections.defaultdict(dict)
+        for lang in cfg.sections():
+            for metric_type in cfg[lang]:
+                self.model_config[lang][metric_type] = cfg.get(section=lang,
+                                                               option=metric_type)  # type: ignore[reportGeneralIssue]  # NOQA:E501
+
+    def reset(self):
+        ''' reset all model used in langcheck to default'''
+        self.__init__config()
+
+    def list_metric_model(self, language: str, metric_type: str):
+        """
+        return the model used in current metric for a given language.
+
+        Args:
+            language: The language for which to get the model.
+            metric_type: The metric name.
+
+        Returns:
+            str: The name of the specified model.
+
+        Raises:
+            KeyError: If the specified language or model type is not found.
+        """
+        if language in self.model_config:
+            if metric_type in self.model_config[language]:
+                return self.model_config[language][metric_type]
+            else:
+                raise KeyError(f"Model type '{metric_type}' not found for language '{language}'.")  # NOQA:E501
+        else:
+            raise KeyError(f"Language '{language}' not supported.")
+
+    def set_model_for_metric(self, language: str,
+                             metric_type: str, model_name: str):
+        """
+        Sets a specific model used in metric_type for a given language.
+
+        Args:
+            language: The language for which to set the model.
+            metric_type: The type of the model (e.g., 'sentiment_model').
+            model_name: The name of the model.
+
+        Raises:
+            KeyError: If the specified language is not supported.
+        """
+        if language in self.model_config:
+            if metric_type in self.model_config[language]:
+                self.model_config[language][metric_type] = model_name
+            else:
+                raise KeyError(f"Metrics '{metric_type}' not used in metric.")
+        else:
+            raise KeyError(f"Language '{language}' not supported.")
+
+    def load_config_from_file(self, file_path: str):
+        """
+        Loads model configurations from a specified configuration file.
+
+        The configuration file should have sections for each language with
+        key-value pairs for each metrics and model_name.
+
+        Args:
+            file_path: The path to the configuration file containing model
+            configurations.
+        """
+        config = configparser.ConfigParser()
+        config.read(file_path)
+
+        for lanuage_section in config.sections():
+            if lanuage_section in self.model_config:
+                for metric_type, model_name in config[lanuage_section].items():
+                    if metric_type in self.model_config[lanuage_section]:
+                        self.model_config[lanuage_section][metric_type] = model_name  # NOQA:E501
+
+    def save_config_to_disk(self, output_path: str):
+        """
+        Save Model Configuration to output path.
+        Args:
+            output_path: The path to save the configuration file
+        """
+        cfg = configparser.ConfigParser()
+        cfg.read_dict(self.model_config)
+
+        with open(output_path, 'w') as f:
+            cfg.write(f)

--- a/src/langcheck/metrics/_model_management.py
+++ b/src/langcheck/metrics/_model_management.py
@@ -1,6 +1,6 @@
 import os
-import configparser
 import collections
+import configparser
 from pathlib import Path
 
 
@@ -28,8 +28,9 @@ class ModelConfig:
         self.model_config = collections.defaultdict(dict)
         for lang in cfg.sections():
             for metric_type in cfg[lang]:
-                self.model_config[lang][metric_type] = cfg.get(section=lang,
-                                                               option=metric_type)  # type: ignore[reportGeneralIssue]  # NOQA:E501
+                self.model_config[lang][metric_type] = cfg.get(
+                    section=lang, option=metric_type
+                )  # type: ignore[reportGeneralIssue]  # NOQA:E501
 
     def reset(self):
         ''' reset all model used in langcheck to default'''
@@ -50,12 +51,14 @@ class ModelConfig:
             if metric_type in self.model_config[language]:
                 print(self.model_config[language][metric_type])
             else:
-                raise KeyError(f"Model type '{metric_type}' not found for language '{language}'.")  # NOQA:E501
+                raise KeyError(
+                    f"Model type '{metric_type}' not found for language '{language}'."
+                )  # NOQA:E501
         else:
             raise KeyError(f"Language '{language}' not supported.")
 
-    def set_model_for_metric(self, language: str,
-                             metric_type: str, model_name: str):
+    def set_model_for_metric(self, language: str, metric_type: str,
+                             model_name: str):
         """
         Sets a specific model used in metric_type for a given language.
 
@@ -93,7 +96,8 @@ class ModelConfig:
             if lanuage_section in self.model_config:
                 for metric_type, model_name in config[lanuage_section].items():
                     if metric_type in self.model_config[lanuage_section]:
-                        self.model_config[lanuage_section][metric_type] = model_name  # NOQA:E501
+                        self.model_config[lanuage_section][
+                            metric_type] = model_name  # NOQA:E501
 
     def save_config_to_disk(self, output_path: str):
         """

--- a/src/langcheck/metrics/_model_management.py
+++ b/src/langcheck/metrics/_model_management.py
@@ -36,6 +36,27 @@ class ModelConfig:
         ''' reset all model used in langcheck to default'''
         self.__init__config()
 
+    def get_metric_model(self, language: str, metric_type: str):
+        """
+        list the model used in current metric for a given language.
+
+        Args:
+            language: The language for which to get the model.
+            metric_type: The metric name.
+
+        Raises:
+            KeyError: If the specified language or model type is not found.
+        """
+        if language in self.model_config:
+            if metric_type in self.model_config[language]:
+                return self.model_config[language][metric_type]
+            else:
+                raise KeyError(
+                    f"Model type '{metric_type}' not found for language '{language}'."  # NOQA:E501
+                )
+        else:
+            raise KeyError(f"Language '{language}' not supported.")
+
     def list_metric_model(self, language: str, metric_type: str):
         """
         list the model used in current metric for a given language.

--- a/src/langcheck/metrics/_model_management.py
+++ b/src/langcheck/metrics/_model_management.py
@@ -37,21 +37,18 @@ class ModelConfig:
 
     def list_metric_model(self, language: str, metric_type: str):
         """
-        return the model used in current metric for a given language.
+        list the model used in current metric for a given language.
 
         Args:
             language: The language for which to get the model.
             metric_type: The metric name.
-
-        Returns:
-            str: The name of the specified model.
 
         Raises:
             KeyError: If the specified language or model type is not found.
         """
         if language in self.model_config:
             if metric_type in self.model_config[language]:
-                return self.model_config[language][metric_type]
+                print(self.model_config[language][metric_type])
             else:
                 raise KeyError(f"Model type '{metric_type}' not found for language '{language}'.")  # NOQA:E501
         else:

--- a/src/langcheck/metrics/modelconfig.ini
+++ b/src/langcheck/metrics/modelconfig.ini
@@ -1,0 +1,10 @@
+[zh]
+# According to the C-MTEB Benchmark
+# (https://github.com/FlagOpen/FlagEmbedding/tree/master/C_MTEB)
+# the 3 models of different sizes provided BAAI are the best on the
+# embedding task
+# Ref: https://huggingface.co/BAAI/bge-base-zh-v1.5
+# Using this model, it is hard to find two sentence where cos_sim < 0.25.
+semantic_similarity = BAAI/bge-base-zh-v1.5
+sentiment = IDEA-CCNL/Erlangshen-Roberta-110M-Sentiment
+toxicity = alibaba-pai/pai-bert-base-zh-llm-risk-detection

--- a/src/langcheck/metrics/zh/reference_based_text_quality.py
+++ b/src/langcheck/metrics/zh/reference_based_text_quality.py
@@ -90,14 +90,12 @@ def semantic_similarity(
                                               openai_args)
         metric_value.language = 'zh'
         return metric_value
-
-    # According to the C-MTEB Benchmark
-    # (https://github.com/FlagOpen/FlagEmbedding/tree/master/C_MTEB)
-    # the 3 models of different sizes provided BAAI are the best on the
-    # embedding task
-    # Ref: https://huggingface.co/BAAI/bge-base-zh-v1.5
-    # Using this model, it is hard to find two sentence where cos_sim < 0.25.
-    model = SentenceTransformer('BAAI/bge-base-zh-v1.5')
+    # lazy import
+    from langcheck.metrics import _model_manager
+    print(_model_manager.list_metric_model(language='zh',
+                                           metric_type='semantic_similarity'))
+    model = SentenceTransformer(_model_manager.list_metric_model(language='zh',
+                                                                 metric_type='semantic_similarity'))  # NOQA: E501
     generated_embeddings = model.encode(generated_outputs)
     reference_embeddings = model.encode(reference_outputs)
     cosine_scores = util.pairwise_cos_sim(

--- a/src/langcheck/metrics/zh/reference_based_text_quality.py
+++ b/src/langcheck/metrics/zh/reference_based_text_quality.py
@@ -92,10 +92,12 @@ def semantic_similarity(
         return metric_value
     # lazy import
     from langcheck.metrics import _model_manager
-    print(_model_manager.list_metric_model(language='zh',
-                                           metric_type='semantic_similarity'))
-    model = SentenceTransformer(_model_manager.list_metric_model(language='zh',
-                                                                 metric_type='semantic_similarity'))  # NOQA: E501
+    print(
+        _model_manager.list_metric_model(language='zh',
+                                         metric_type='semantic_similarity'))
+    model = SentenceTransformer(
+        _model_manager.list_metric_model(
+            language='zh', metric_type='semantic_similarity'))  # NOQA: E501
     generated_embeddings = model.encode(generated_outputs)
     reference_embeddings = model.encode(reference_outputs)
     cosine_scores = util.pairwise_cos_sim(

--- a/src/langcheck/metrics/zh/reference_based_text_quality.py
+++ b/src/langcheck/metrics/zh/reference_based_text_quality.py
@@ -92,11 +92,8 @@ def semantic_similarity(
         return metric_value
     # lazy import
     from langcheck.metrics import _model_manager
-    print(
-        _model_manager.list_metric_model(language='zh',
-                                         metric_type='semantic_similarity'))
     model = SentenceTransformer(
-        _model_manager.list_metric_model(
+        _model_manager.get_metric_model(
             language='zh', metric_type='semantic_similarity'))  # NOQA: E501
     generated_embeddings = model.encode(generated_outputs)
     reference_embeddings = model.encode(reference_outputs)

--- a/tests/metrics/test_model_management.py
+++ b/tests/metrics/test_model_management.py
@@ -1,4 +1,5 @@
 from unittest.mock import mock_open, patch
+
 from langcheck.metrics._model_management import ModelConfig
 
 
@@ -7,7 +8,8 @@ def test_initialization_with_mock_file():
         mock_file_content = "[zh]\nsemantic_similarity=test_model\n"
         with patch('builtins.open', mock_open(read_data=mock_file_content)):
             config = ModelConfig()
-            assert config.model_config['zh']['semantic_similarity'] == 'test_model'  # NOQA:E501
+            assert config.model_config['zh'][
+                'semantic_similarity'] == 'test_model'  # NOQA:E501
     except AssertionError as err:
         raise err
 
@@ -33,6 +35,7 @@ def test_set_model_for_metric_with_mock_file():
             config.set_model_for_metric(model_name='another_test_model',
                                         language='zh',
                                         metric_type='semantic_similarity')
-            assert config.model_config['zh']['semantic_similarity'] == 'another_test_model'  # NOQA:E501
+            assert config.model_config['zh'][
+                'semantic_similarity'] == 'another_test_model'  # NOQA:E501
     except AssertionError as err:
         raise err

--- a/tests/metrics/test_model_management.py
+++ b/tests/metrics/test_model_management.py
@@ -14,6 +14,18 @@ def test_initialization_with_mock_file():
         raise err
 
 
+def test_get_metric_model_with_mock_file():
+    try:
+        mock_file_content = "[zh]\nsemantic_similarity=test_model\n"
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            config = ModelConfig()
+            model_name = config.get_metric_model(
+                language='zh', metric_type='semantic_similarity')  # NOQA:E501
+            assert model_name == 'test_model'
+    except AssertionError as err:
+        raise err
+
+
 def test_list_metric_model_with_mock_file(capsys):
     try:
         mock_file_content = "[zh]\nsemantic_similarity=test_model\n"

--- a/tests/metrics/test_model_management.py
+++ b/tests/metrics/test_model_management.py
@@ -1,0 +1,38 @@
+from unittest.mock import mock_open, patch
+from langcheck.metrics._model_management import ModelConfig
+
+
+def test_initialization_with_mock_file():
+    try:
+        mock_file_content = "[zh]\nsemantic_similarity=test_model\n"
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            config = ModelConfig()
+            assert config.model_config['zh']['semantic_similarity'] == 'test_model'  # NOQA:E501
+    except AssertionError as err:
+        raise err
+
+
+def test_list_metric_model_with_mock_file(capsys):
+    try:
+        mock_file_content = "[zh]\nsemantic_similarity=test_model\n"
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            config = ModelConfig()
+            config.list_metric_model(language='zh',
+                                     metric_type='semantic_similarity')
+            captured = capsys.readouterr()  # type: ignore
+            assert 'test_model' in captured.out
+    except AssertionError as err:
+        raise err
+
+
+def test_set_model_for_metric_with_mock_file():
+    try:
+        mock_file_content = "[zh]\nsemantic_similarity=test_model\n"
+        with patch('builtins.open', mock_open(read_data=mock_file_content)):
+            config = ModelConfig()
+            config.set_model_for_metric(model_name='another_test_model',
+                                        language='zh',
+                                        metric_type='semantic_similarity')
+            assert config.model_config['zh']['semantic_similarity'] == 'another_test_model'  # NOQA:E501
+    except AssertionError as err:
+        raise err


### PR DESCRIPTION
implement a model manager class for centralized type model management.

the model manager can manage transformer models used in different metric for different language. The manager support list_model_in_use, set_model_for_metric, reset, load_from_file, and save_to_disk, by using this, I think langcheck can have

- [x] a centralized evalution model management
- [x] allow user to use the model they perfered, because langcheck may not update the SOTA model as soon as possible.
- [ ] replace the pydoc in same metric in different language that only has a little differernce with the same one.

As it is a prototype, so I base it on zh-support branch to make it do not influence any in-progress feature update.
it can work like this,
![屏幕截图 2023-12-10 175028](https://github.com/citadel-ai/langcheck/assets/59645193/f6e23932-61b1-4a20-97c6-2ca7e7a7ea74)


