### PR TITLE
Metric to compute context relevance

### DIFF
--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -4,7 +4,8 @@ from langcheck.metrics.en.reference_based_text_quality import (
 from langcheck.metrics.en.reference_free_text_quality import (
     ai_disclaimer_similarity, flesch_kincaid_grade, flesch_reading_ease,
     fluency, sentiment, toxicity)
-from langcheck.metrics.en.source_based_text_quality import factual_consistency
+from langcheck.metrics.en.source_based_text_quality import (context_relevance,
+                                                            factual_consistency)
 from langcheck.metrics.metric_value import MetricValue
 from langcheck.metrics.reference_based_text_quality import exact_match
 from langcheck.metrics.text_structure import (contains_all_strings,
@@ -20,6 +21,7 @@ __all__ = [
     'contains_all_strings',
     'contains_any_strings',
     'contains_regex',
+    'context_relevance',
     'MetricValue',
     'exact_match',
     'factual_consistency',

--- a/src/langcheck/metrics/_validation.py
+++ b/src/langcheck/metrics/_validation.py
@@ -103,6 +103,39 @@ def validate_parameters_source_based(
     return _generated_outputs, _sources, _prompts
 
 
+def validate_parameters_context_relevance(
+        prompts: List[str] | str,
+        sources: List[str] | str) -> tuple[List[str], List[str]]:
+    '''Validates and parses function parameters for the context relevance
+    metric.
+
+    Args:
+        prompts: The prompt(s)
+        sources: The source(s)
+
+    Returns:
+        A tuple (prompts, sources) of the parsed parameters, converted to lists
+        of strings.
+    '''
+    # Convert single-string parameters to lists
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    if isinstance(sources, str):
+        sources = [sources]
+
+    # Check that prompts and sources are not empty
+    if not prompts:
+        raise ValueError('Please specify at least one prompt')
+    if not sources:
+        raise ValueError('Please specify at least one source')
+
+    # Check that the lengths of lists match
+    if len(prompts) != len(sources):
+        raise ValueError('The number of prompts and sources do not match')
+
+    return prompts, sources
+
+
 def _validate_parameters(
     generated_outputs: List[str] | str, prompts: Optional[List[str] | str],
     reference_outputs: Optional[List[str] | str],

--- a/src/langcheck/metrics/en/__init__.py
+++ b/src/langcheck/metrics/en/__init__.py
@@ -3,10 +3,12 @@ from langcheck.metrics.en.reference_based_text_quality import (
 from langcheck.metrics.en.reference_free_text_quality import (
     ai_disclaimer_similarity, flesch_kincaid_grade, flesch_reading_ease,
     fluency, sentiment, toxicity)
-from langcheck.metrics.en.source_based_text_quality import factual_consistency
+from langcheck.metrics.en.source_based_text_quality import (context_relevance,
+                                                            factual_consistency)
 
 __all__ = [
     'ai_disclaimer_similarity',
+    'context_relevance',
     'factual_consistency',
     'flesch_kincaid_grade',
     'flesch_reading_ease',

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -10,7 +10,8 @@ from transformers.models.auto.configuration_auto import AutoConfig
 from transformers.models.auto.modeling_auto import AutoModelForSeq2SeqLM
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
-from langcheck.metrics._validation import validate_parameters_source_based
+from langcheck.metrics._validation import (
+    validate_parameters_context_relevance, validate_parameters_source_based)
 from langcheck.metrics.en._openai import OpenAIBasedEvaluator
 from langcheck.metrics.metric_value import MetricValue
 from langcheck.utils.progess_bar import tqdm_wrapper
@@ -345,11 +346,7 @@ def context_relevance(
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
     '''
-    # TODO: Move this to validation
-    if isinstance(prompts, str):
-        prompts = [prompts]
-    if isinstance(sources, str):
-        sources = [sources]
+    prompts, sources = validate_parameters_context_relevance(prompts, sources)
 
     def _prompt(src: str, user_query: str) -> str:
         return f'''

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -306,3 +306,119 @@ def _factual_consistency_openai(
         score_list.append(score)
         explanation_list.append(explanation)
     return score_list, explanation_list
+
+
+def context_relevance(
+    sources: List[str] | str,
+    prompts: List[str] | str,
+    model_type: str = 'openai',
+    openai_client: Optional[OpenAI] = None,
+    openai_args: Optional[Dict[str,
+                               str]] = None) -> MetricValue[Optional[float]]:
+    '''Calculates the relevance of the sources to the prompts. This metric takes
+    on float values between [0, 1], where 0 means that the source text is not at
+    all relevant to the prompt, and 1 means that the source text is fully
+    relevant to the prompt.
+
+    We currently support two model types:
+
+    1. The 'openai' type, where we use OpenAI's 'gpt-turbo-3.5' model
+    by default. While the model you use is configurable, please make sure to use
+    one that supports function calling
+    (https://platform.openai.com/docs/guides/gpt/function-calling). See
+    `this page <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
+    for examples on setting up the OpenAI API key.
+
+    2. The 'azure_openai' type. Essentially the same as the 'openai' type,
+    except that it uses the AzureOpenAI client. Note that you must specify your
+    model deployment to use in ``openai_args``, e.g.
+    ``openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}``
+
+    Args:
+        sources: The source text(s), one string per prompt
+        prompts: The prompt(s)
+        model_type: The type of model to use ('openai' or 'azure_openai'),
+            default 'openai'
+        openai_client: OpenAI or AzureOpenAI client, default None. If this is
+            None, we will attempt to create a default client.
+        openai_args: Dict of additional args to pass in to the
+            ``client.chat.completions.create`` function, default None
+    '''
+    # TODO: Move this to validation
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    if isinstance(sources, str):
+        sources = [sources]
+
+    def _prompt(src: str, user_query: str) -> str:
+        return f'''
+        You are evaluating the relevance of the source to a user's query. Here
+        is the data:
+        [BEGIN DATA]
+        ************
+        [Source]: {src}
+        ************
+        [User Query]: {user_query}
+        ************
+        [END DATA]
+
+        Determine whether the source contains the relevant and necessary
+        information needed to respond to the user's query. The available
+        assessments are:
+        `Fully Relevant` - The source text contains the information necessary to
+        respond to the user's query.
+        `Partially Relevant` - The source text is partially relevant to the
+        user's query, but does not contain all the information necessary to
+        respond to the user's query.
+        `Not Relevant` - The source text is not relevant to the user's query.
+
+        Take a deep breath and work on this problem step-by-step.
+        '''
+
+    def _function_call_prompt(long_assessment: str) -> str:
+        return f'''
+        The following is an assessment on the relevance of a source:
+        ************
+        [Assessment]: {long_assessment}
+        ************
+
+        Save the resulting assessment. The available assessments are:
+        `Fully Relevant`
+        `Partially Relevant`
+        `Not Relevant`
+        '''
+
+    context_relevance_assessment_to_score = {
+        'Fully Relevant': 1.0,
+        'Partially Relevant': 0.5,
+        'Not Relevant': 0.0
+    }
+    oai_evaluator = OpenAIBasedEvaluator(
+        assessment_to_score_mapping=context_relevance_assessment_to_score,
+        function_name='save_context_relevance_assessment',
+        function_description=("Saves a context relevance assessment."),
+        argument_name='context_relevance',
+        argument_description='The context relevance assessment',
+        client_type=model_type,
+        client=openai_client,
+        openai_args=openai_args)
+
+    score_list = []
+    explanation_list = []
+    for src, user_query in tqdm_wrapper(zip(sources, prompts),
+                                        desc='Calculating scores',
+                                        total=len(prompts)):
+        score, explanation = oai_evaluator.get_score(
+            _prompt(src=src, user_query=user_query), _function_call_prompt)
+        score_list.append(score)
+        explanation_list.append(explanation)
+
+    return MetricValue(metric_name='context_relevance',
+                       prompts=prompts,
+                       generated_outputs=None,
+                       reference_outputs=None,
+                       sources=sources,
+                       explanations=explanation_list,
+                       metric_values=score_list,
+                       language='en')

--- a/src/langcheck/metrics/ja/__init__.py
+++ b/src/langcheck/metrics/ja/__init__.py
@@ -3,10 +3,11 @@ from langcheck.metrics.ja.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.ja.reference_free_text_quality import (
     fluency, sentiment, tateishi_ono_yamada_reading_ease, toxicity)
-from langcheck.metrics.ja.source_based_text_quality import factual_consistency
+from langcheck.metrics.ja.source_based_text_quality import (context_relevance,
+                                                            factual_consistency)
 
 __all__ = [
-    'factual_consistency', 'JanomeTokenizer', 'MeCabTokenizer', 'rouge1',
-    'rouge2', 'rougeL', 'semantic_similarity', 'fluency', 'sentiment',
-    'tateishi_ono_yamada_reading_ease', 'toxicity'
+    'context_relevance', 'factual_consistency', 'JanomeTokenizer',
+    'MeCabTokenizer', 'rouge1', 'rouge2', 'rougeL', 'semantic_similarity',
+    'fluency', 'sentiment', 'tateishi_ono_yamada_reading_ease', 'toxicity'
 ]

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -6,10 +6,13 @@ from openai import OpenAI
 from transformers.pipelines import pipeline
 from transformers.pipelines.base import Pipeline
 
-from langcheck.metrics._validation import validate_parameters_source_based
+from langcheck.metrics._validation import (
+    validate_parameters_context_relevance, validate_parameters_source_based)
+from langcheck.metrics.en._openai import OpenAIBasedEvaluator
 from langcheck.metrics.en.source_based_text_quality import \
     factual_consistency as en_factual_consistency
 from langcheck.metrics.metric_value import MetricValue
+from langcheck.utils.progess_bar import tqdm_wrapper
 
 _factual_consistency_translation_model_path = 'Helsinki-NLP/opus-mt-ja-en'
 _factual_consistency_translation_pipeline: Pipeline | None = None
@@ -117,4 +120,113 @@ def factual_consistency(
                        sources=sources,
                        explanations=None,
                        metric_values=factual_consistency_scores,
+                       language='ja')
+
+
+def context_relevance(
+    sources: List[str] | str,
+    prompts: List[str] | str,
+    model_type: str = 'openai',
+    openai_client: Optional[OpenAI] = None,
+    openai_args: Optional[Dict[str,
+                               str]] = None) -> MetricValue[Optional[float]]:
+    '''Calculates the relevance of the sources to the prompts. This metric takes
+    on float values between [0, 1], where 0 means that the source text is not at
+    all relevant to the prompt, and 1 means that the source text is fully
+    relevant to the prompt.
+
+    We currently support two model types:
+
+    1. The 'openai' type, where we use OpenAI's 'gpt-turbo-3.5' model
+    by default. While the model you use is configurable, please make sure to use
+    one that supports function calling
+    (https://platform.openai.com/docs/guides/gpt/function-calling). See
+    `this page <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
+    for examples on setting up the OpenAI API key.
+
+    2. The 'azure_openai' type. Essentially the same as the 'openai' type,
+    except that it uses the AzureOpenAI client. Note that you must specify your
+    model deployment to use in ``openai_args``, e.g.
+    ``openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}``
+
+    Args:
+        sources: The source text(s), one string per prompt
+        prompts: The prompt(s)
+        model_type: The type of model to use ('openai' or 'azure_openai'),
+            default 'openai'
+        openai_client: OpenAI or AzureOpenAI client, default None. If this is
+            None, we will attempt to create a default client.
+        openai_args: Dict of additional args to pass in to the
+            ``client.chat.completions.create`` function, default None
+    '''
+    prompts, sources = validate_parameters_context_relevance(prompts, sources)
+
+    def _prompt(src: str, user_query: str) -> str:
+        return f'''
+        ユーザーの質問に対してソースの関連性を評価してください。データは以下の通りです:
+        [BEGIN DATA]
+        ************
+        [ソース]: {src}
+        ************
+        [ユーザーの質問]: {user_query}
+        ************
+        [END DATA]
+
+        ユーザーの質問に対応するために必要な、関連性のある情報がソースに含まれているかを判断
+        してください。利用可能な評価は以下の通りです:
+        `完全に関連` - ソーステキストには、ユーザーの質問に対応するために必要な情報が
+        含まれています。
+        `部分的に関連` - ソーステキストはユーザーの質問に部分的に関連していますが、質問に
+        対応するために必要なすべての情報を含んでいません。
+        `関連なし` - ソーステキストはユーザーの質問に関連していません。
+
+        深呼吸をして、この問題をステップバイステップで取り組んでください。
+        '''
+
+    def _function_call_prompt(long_assessment: str) -> str:
+        return f'''
+        以下はソースの関連性に関する評価です:
+        ************
+        [評価]: {long_assessment}
+        ************
+
+        結果として出た評価を保存してください。利用可能な評価は以下の通りです:
+        `完全に関連`
+        `部分的に関連`
+        `関連なし`
+        '''
+
+    context_relevance_assessment_to_score = {
+        '完全に関連': 1.0,
+        '部分的に関連': 0.5,
+        '関連なし': 0.0
+    }
+    oai_evaluator = OpenAIBasedEvaluator(
+        assessment_to_score_mapping=context_relevance_assessment_to_score,
+        function_name='save_context_relevance_assessment',
+        function_description=("Saves a context relevance assessment."),
+        argument_name='context_relevance',
+        argument_description='The context relevance assessment',
+        client_type=model_type,
+        client=openai_client,
+        openai_args=openai_args)
+
+    score_list = []
+    explanation_list = []
+    for src, user_query in tqdm_wrapper(zip(sources, prompts),
+                                        desc='Calculating scores',
+                                        total=len(prompts)):
+        score, explanation = oai_evaluator.get_score(
+            _prompt(src=src, user_query=user_query), _function_call_prompt)
+        score_list.append(score)
+        explanation_list.append(explanation)
+
+    return MetricValue(metric_name='context_relevance',
+                       prompts=prompts,
+                       generated_outputs=None,
+                       reference_outputs=None,
+                       sources=sources,
+                       explanations=explanation_list,
+                       metric_values=score_list,
                        language='ja')

--- a/src/langcheck/metrics/metric_value.py
+++ b/src/langcheck/metrics/metric_value.py
@@ -19,7 +19,7 @@ class MetricValue(Generic[NumericType]):
     metric_name: str
     metric_values: List[NumericType]
     prompts: Optional[List[str]]
-    generated_outputs: List[str]
+    generated_outputs: Optional[List[str]]
     reference_outputs: Optional[List[str]]
     sources: Optional[List[str]]
     explanations: Optional[List[Optional[

--- a/src/langcheck/plot/_scatter.py
+++ b/src/langcheck/plot/_scatter.py
@@ -68,7 +68,7 @@ def _scatter_one_metric_value(metric_value: MetricValue,
     df['source'] = df['source'].fillna('None').apply(_format_text_for_hover)
     df['explanation'] = df['explanation'].fillna('None').apply(
         _format_text_for_hover)
-    df['generated_output'] = df['generated_output'].apply(
+    df['generated_output'] = df['generated_output'].fillna('None').apply(
         _format_text_for_hover)
 
     # Define layout of the Dash app (chart + search boxes)
@@ -213,7 +213,7 @@ def _scatter_two_metric_values(metric_value: MetricValue,
     df['source'] = df['source'].fillna('None').apply(_format_text_for_hover)
     df['explanation'] = df['explanation'].fillna('None').apply(
         _format_text_for_hover)
-    df['generated_output'] = df['generated_output'].apply(
+    df['generated_output'] = df['generated_output'].fillna('None').apply(
         _format_text_for_hover)
 
     # Define layout of the Dash app (chart + search boxes)

--- a/tests/metrics/en/test_source_based_text_quality.py
+++ b/tests/metrics/en/test_source_based_text_quality.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 from openai.types.chat import ChatCompletion
 
-from langcheck.metrics.en import factual_consistency
+from langcheck.metrics.en import context_relevance, factual_consistency
 
 ################################################################################
 # Tests
@@ -61,4 +61,37 @@ def test_factual_consistency_openai(generated_outputs, sources):
                                            model_type='azure_openai',
                                            openai_args={'model': 'foo bar'})
         # "Fully Consistent" gets a value of 1.0
+        assert metric_value == 1
+
+
+@pytest.mark.parametrize(
+    'prompts,sources',
+    [('What is the capital of Japan?', "Tokyo is Japan's capital city."),
+     (['What is the capital of Japan?'], ["Tokyo is Japan's capital city."])])
+def test_context_relevance_openai(prompts, sources):
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(function_call=Mock(
+            arguments="{\n  \"context_relevance\": \"Fully Relevant\"\n}")))
+    ]
+
+    # Calling the openai.resources.chat.Completions.create method requires an
+    # OpenAI API key, so we mock the return value instead
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        metric_value = context_relevance(prompts, sources, model_type='openai')
+        # "Fully Relevant" gets a value of 1.0
+        assert metric_value == 1
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        metric_value = context_relevance(prompts,
+                                         sources,
+                                         model_type='azure_openai',
+                                         openai_args={'model': 'foo bar'})
+        # "Fully Relevant" gets a value of 1.0
         assert metric_value == 1

--- a/tests/metrics/ja/test_source_based_text_quality.py
+++ b/tests/metrics/ja/test_source_based_text_quality.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 from openai.types.chat import ChatCompletion
 
-from langcheck.metrics.ja import factual_consistency
+from langcheck.metrics.ja import context_relevance, factual_consistency
 
 ################################################################################
 # Tests
@@ -57,4 +57,36 @@ def test_factual_consistency_openai(generated_outputs, sources):
                                            model_type='azure_openai',
                                            openai_args={'model': 'foo bar'})
         # "Fully Consistent" gets a value of 1.0
+        assert metric_value == 1
+
+
+@pytest.mark.parametrize('prompts,sources',
+                         [('日本の首都は何ですか？', "東京は日本の首都です。"),
+                          (['日本の首都は何ですか？'], ["東京は日本の首都です。"])])
+def test_context_relevance_openai(prompts, sources):
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(function_call=Mock(
+            arguments="{\n  \"context_relevance\": \"完全に関連\"\n}")))
+    ]
+
+    # Calling the openai.resources.chat.Completions.create method requires an
+    # OpenAI API key, so we mock the return value instead
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        metric_value = context_relevance(prompts, sources, model_type='openai')
+        # "完全に関連" gets a value of 1.0
+        assert metric_value == 1
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        metric_value = context_relevance(prompts,
+                                         sources,
+                                         model_type='azure_openai',
+                                         openai_args={'model': 'foo bar'})
+        # "完全に関連" gets a value of 1.0
         assert metric_value == 1

--- a/tests/metrics/test_text_structure.py
+++ b/tests/metrics/test_text_structure.py
@@ -33,6 +33,7 @@ def test_is_int(generated_outputs, domain, metric_values):
     metric_value = is_int(generated_outputs, domain)
     assert metric_value.metric_name == 'is_int'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -60,6 +61,7 @@ def test_is_float(generated_outputs, min, max, metric_values):
     metric_value = is_float(generated_outputs, min, max)
     assert metric_value.metric_name == 'is_float'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -81,6 +83,7 @@ def test_is_json_array(generated_outputs, metric_values):
     metric_value = is_json_array(generated_outputs)
     assert metric_value.metric_name == 'is_json_array'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -102,6 +105,7 @@ def test_is_json_object(generated_outputs, metric_values):
     metric_value = is_json_object(generated_outputs)
     assert metric_value.metric_name == 'is_json_object'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -135,6 +139,7 @@ def test_matches_regex(generated_outputs, regex, metric_values):
     metric_value = matches_regex(generated_outputs, regex)
     assert metric_value.metric_name == 'matches_regex'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -164,6 +169,7 @@ def test_contains_regex(generated_outputs, regex, metric_values):
     metric_value = contains_regex(generated_outputs, regex)
     assert metric_value.metric_name == 'contains_regex'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -209,6 +215,7 @@ def test_contains_all_strings(generated_outputs, strings, case_sensitive,
                                         case_sensitive)
     assert metric_value.metric_name == 'contains_all_strings'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -254,6 +261,7 @@ def test_contains_any_strings(generated_outputs, strings, case_sensitive,
                                         case_sensitive)
     assert metric_value.metric_name == 'contains_any_strings'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -270,5 +278,6 @@ def test_validation_fn(generated_outputs, valid_fn, metric_values):
     metric_value = validation_fn(generated_outputs, valid_fn)
     assert metric_value.metric_name == 'validation_fn'
     assert metric_value.prompts is None
+    assert metric_value.generated_outputs is not None
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)


### PR DESCRIPTION
Adds a metric to compute how relevant the retrieved source (i.e. context) is to the user's prompt by asking OpenAI. The English and Japanese versions have different prompts, so that the explanations will be written in the appropriate language.