### PR TITLE
Metric to compute answer relevance

### DIFF
--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -2,8 +2,8 @@ from langcheck.metrics import en, ja
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.en.reference_free_text_quality import (
-    ai_disclaimer_similarity, flesch_kincaid_grade, flesch_reading_ease,
-    fluency, sentiment, toxicity)
+    ai_disclaimer_similarity, answer_relevance, flesch_kincaid_grade,
+    flesch_reading_ease, fluency, sentiment, toxicity)
 from langcheck.metrics.en.source_based_text_quality import (context_relevance,
                                                             factual_consistency)
 from langcheck.metrics.metric_value import MetricValue
@@ -18,6 +18,7 @@ __all__ = [
     'en',
     'ja',
     'ai_disclaimer_similarity',
+    'answer_relevance',
     'contains_all_strings',
     'contains_any_strings',
     'contains_regex',

--- a/src/langcheck/metrics/_validation.py
+++ b/src/langcheck/metrics/_validation.py
@@ -136,6 +136,40 @@ def validate_parameters_context_relevance(
     return prompts, sources
 
 
+def validate_parameters_answer_relevance(
+        generated_outputs: List[str] | str,
+        prompts: List[str] | str) -> tuple[List[str], List[str]]:
+    '''Validates and parses function parameters for the answer relevance
+    metric.
+
+    Args:
+        generated_outputs: The model generated output(s) to evaluate
+        prompts: The prompt(s)
+
+    Returns:
+        A tuple (generated_outputs, prompts) of the parsed parameters, converted
+        to lists of strings.
+    '''
+    # Convert single-string parameters to lists
+    if isinstance(generated_outputs, str):
+        generated_outputs = [generated_outputs]
+    if isinstance(prompts, str):
+        prompts = [prompts]
+
+    # Check that generated_outputs and prompts are not empty
+    if not generated_outputs:
+        raise ValueError('Please specify at least one generated output')
+    if not prompts:
+        raise ValueError('Please specify at least one prompt')
+
+    # Check that the lengths of lists match
+    if len(generated_outputs) != len(prompts):
+        raise ValueError(
+            'The number of generated_outputs and prompts and do not match')
+
+    return generated_outputs, prompts
+
+
 def _validate_parameters(
     generated_outputs: List[str] | str, prompts: Optional[List[str] | str],
     reference_outputs: Optional[List[str] | str],

--- a/src/langcheck/metrics/en/__init__.py
+++ b/src/langcheck/metrics/en/__init__.py
@@ -1,13 +1,14 @@
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.en.reference_free_text_quality import (
-    ai_disclaimer_similarity, flesch_kincaid_grade, flesch_reading_ease,
-    fluency, sentiment, toxicity)
+    ai_disclaimer_similarity, answer_relevance, flesch_kincaid_grade,
+    flesch_reading_ease, fluency, sentiment, toxicity)
 from langcheck.metrics.en.source_based_text_quality import (context_relevance,
                                                             factual_consistency)
 
 __all__ = [
     'ai_disclaimer_similarity',
+    'answer_relevance',
     'context_relevance',
     'factual_consistency',
     'flesch_kincaid_grade',

--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -761,7 +761,7 @@ def ai_disclaimer_similarity(
 def answer_relevance(
     generated_outputs: List[str] | str,
     prompts: List[str] | str,
-    model_type: str = 'local',
+    model_type: str = 'openai',
     openai_client: Optional[OpenAI] = None,
     openai_args: Optional[Dict[str,
                                str]] = None) -> MetricValue[Optional[float]]:
@@ -787,6 +787,10 @@ def answer_relevance(
     '''
     generated_outputs, prompts = validate_parameters_answer_relevance(
         generated_outputs, prompts)
+    assert model_type in [
+        'openai', 'azure_openai'
+    ], ('Unsupported model type. '
+        'The supported ones are ["openai", "azure_openai"]')
 
     def _prompt(gen_output: str, user_query: str) -> str:
         return f'''

--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -9,7 +9,8 @@ from transformers.models.auto.modeling_auto import \
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
 from langcheck._handle_logs import _handle_logging_level
-from langcheck.metrics._validation import validate_parameters_reference_free
+from langcheck.metrics._validation import (validate_parameters_answer_relevance,
+                                           validate_parameters_reference_free)
 from langcheck.metrics.en._detoxify import Detoxify
 from langcheck.metrics.en._openai import OpenAIBasedEvaluator
 from langcheck.metrics.en.reference_based_text_quality import \
@@ -784,7 +785,7 @@ def answer_relevance(
     model deployment to use in ``openai_args``, e.g.
     ``openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}``
     '''
-    generated_outputs, prompts = validate_parameters_reference_free(
+    generated_outputs, prompts = validate_parameters_answer_relevance(
         generated_outputs, prompts)
 
     def _prompt(gen_output: str, user_query: str) -> str:

--- a/src/langcheck/metrics/ja/__init__.py
+++ b/src/langcheck/metrics/ja/__init__.py
@@ -2,12 +2,14 @@ from langcheck.metrics.ja._tokenizers import JanomeTokenizer, MeCabTokenizer
 from langcheck.metrics.ja.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.ja.reference_free_text_quality import (
-    fluency, sentiment, tateishi_ono_yamada_reading_ease, toxicity)
+    answer_relevance, fluency, sentiment, tateishi_ono_yamada_reading_ease,
+    toxicity)
 from langcheck.metrics.ja.source_based_text_quality import (context_relevance,
                                                             factual_consistency)
 
 __all__ = [
-    'context_relevance', 'factual_consistency', 'JanomeTokenizer',
-    'MeCabTokenizer', 'rouge1', 'rouge2', 'rougeL', 'semantic_similarity',
-    'fluency', 'sentiment', 'tateishi_ono_yamada_reading_ease', 'toxicity'
+    'answer_relevance', 'context_relevance', 'factual_consistency',
+    'JanomeTokenizer', 'MeCabTokenizer', 'rouge1', 'rouge2', 'rougeL',
+    'semantic_similarity', 'fluency', 'sentiment',
+    'tateishi_ono_yamada_reading_ease', 'toxicity'
 ]

--- a/tests/metrics/ja/test_reference_free_text_quality.py
+++ b/tests/metrics/ja/test_reference_free_text_quality.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 from openai.types.chat import ChatCompletion
 
-from langcheck.metrics.ja import (fluency, sentiment,
+from langcheck.metrics.ja import (answer_relevance, fluency, sentiment,
                                   tateishi_ono_yamada_reading_ease, toxicity)
 from tests.utils import is_close
 
@@ -136,3 +136,37 @@ def test_fluency_openai(generated_outputs):
 def test_tateishi_ono_yamada_reading_ease(generated_outputs, metric_values):
     metric_value = tateishi_ono_yamada_reading_ease(generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
+
+
+@pytest.mark.parametrize('generated_outputs,prompts',
+                         [('東京は日本の首都です。', '日本の首都は何ですか？'),
+                          (['東京は日本の首都です。'], ['日本の首都は何ですか？'])])
+def test_answer_relevance_openai(generated_outputs, prompts):
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(function_call=Mock(
+            arguments="{\n  \"answer_relevance\": \"完全に関連\"\n}")))
+    ]
+
+    # Calling the openai.resources.chat.Completions.create method requires an
+    # OpenAI API key, so we mock the return value instead
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        metric_value = answer_relevance(generated_outputs,
+                                        prompts,
+                                        model_type='openai')
+        # "完全に関連" gets a value of 1.0
+        assert metric_value == 1
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        metric_value = answer_relevance(generated_outputs,
+                                        prompts,
+                                        model_type='azure_openai',
+                                        openai_args={'model': 'foo bar'})
+        # "完全に関連" gets a value of 1.0
+        assert metric_value == 1


### PR DESCRIPTION
Adds a metric to compute how relevant the generated output is to the user's prompt by asking OpenAI. The English and Japanese versions have different prompts, so that the explanations will be written in the appropriate language.

This is related to https://github.com/citadel-ai/langcheck/pull/76, but measure's the answer's relevance to the prompt instead of the retrieved context's to the prompt.