### PR TITLE
Update OpenAI embedding model for semantic similarity

### DIFF
--- a/src/langcheck/metrics/de/reference_based_text_quality.py
+++ b/src/langcheck/metrics/de/reference_based_text_quality.py
@@ -51,7 +51,7 @@ def semantic_similarity(
     Ref:
         https://huggingface.co/tasks/sentence-similarity
         https://www.sbert.net/docs/usage/semantic_textual_similarity.html
-        https://openai.com/blog/new-and-improved-embedding-model
+        https://openai.com/blog/new-embedding-models-and-api-updates
 
     Args:
         generated_outputs: The model generated output(s) to evaluate

--- a/src/langcheck/metrics/de/reference_based_text_quality.py
+++ b/src/langcheck/metrics/de/reference_based_text_quality.py
@@ -39,7 +39,7 @@ def semantic_similarity(
     from HuggingFace and run locally. This is the default model type and
     there is no setup needed to run this.
 
-    2. The 'openai' type, where we use OpenAI's 'text-embedding-ada-002' model
+    2. The 'openai' type, where we use OpenAI's 'text-embedding-3-small' model
     by default (this is configurable). See
     `this page <https://langcheck.readthedocs.io/en/latest/metrics.html
     #computing-metrics-with-openai-models>`__

--- a/src/langcheck/metrics/de/reference_based_text_quality.py
+++ b/src/langcheck/metrics/de/reference_based_text_quality.py
@@ -29,9 +29,7 @@ def semantic_similarity(
     the reference outputs. The similarities are computed as the cosine
     similarities between the generated and reference embeddings. This metric
     takes on float values between [-1, 1], but typically ranges between 0 and 1
-    where 0 is minimum similarity and 1 is maximum similarity. (NOTE: when using
-    OpenAI embeddings, the cosine similarities tend to be skewed quite heavily
-    towards higher numbers.)
+    where 0 is minimum similarity and 1 is maximum similarity.
 
     We currently support three embedding model types:
 

--- a/src/langcheck/metrics/en/reference_based_text_quality.py
+++ b/src/langcheck/metrics/en/reference_based_text_quality.py
@@ -24,9 +24,7 @@ def semantic_similarity(
     the reference outputs. The similarities are computed as the cosine
     similarities between the generated and reference embeddings. This metric
     takes on float values between [-1, 1], but typically ranges between 0 and 1
-    where 0 is minimum similarity and 1 is maximum similarity. (NOTE: when using
-    OpenAI embeddings, the cosine similarities tend to be skewed quite heavily
-    towards higher numbers.)
+    where 0 is minimum similarity and 1 is maximum similarity.
 
     We currently support three embedding model types:
 

--- a/src/langcheck/metrics/en/reference_based_text_quality.py
+++ b/src/langcheck/metrics/en/reference_based_text_quality.py
@@ -46,7 +46,7 @@ def semantic_similarity(
     Ref:
         https://huggingface.co/tasks/sentence-similarity
         https://www.sbert.net/docs/usage/semantic_textual_similarity.html
-        https://openai.com/blog/new-and-improved-embedding-model
+        https://openai.com/blog/new-embedding-models-and-api-updates
 
     Args:
         generated_outputs: The model generated output(s) to evaluate

--- a/src/langcheck/metrics/en/reference_based_text_quality.py
+++ b/src/langcheck/metrics/en/reference_based_text_quality.py
@@ -34,7 +34,7 @@ def semantic_similarity(
     from HuggingFace and run locally. This is the default model type and
     there is no setup needed to run this.
 
-    2. The 'openai' type, where we use OpenAI's 'text-embedding-ada-002' model
+    2. The 'openai' type, where we use OpenAI's 'text-embedding-3-small' model
     by default (this is configurable). See
     `this page <https://langcheck.readthedocs.io/en/latest/metrics.html
     #computing-metrics-with-openai-models>`__
@@ -124,10 +124,10 @@ def semantic_similarity(
             if openai_args is None:
                 batch_gen_embed_response = openai_client.embeddings.create(
                     input=batch_generated_outputs,
-                    model='text-embedding-ada-002')
+                    model='text-embedding-3-small')
                 batch_ref_embed_response = openai_client.embeddings.create(
                     input=batch_reference_outputs,
-                    model='text-embedding-ada-002')
+                    model='text-embedding-3-small')
             else:
                 batch_gen_embed_response = openai_client.embeddings.create(
                     input=batch_generated_outputs, **openai_args)

--- a/src/langcheck/metrics/ja/reference_based_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_based_text_quality.py
@@ -49,7 +49,7 @@ def semantic_similarity(
     Ref:
         https://huggingface.co/tasks/sentence-similarity
         https://www.sbert.net/docs/usage/semantic_textual_similarity.html
-        https://openai.com/blog/new-and-improved-embedding-model
+        https://openai.com/blog/new-embedding-models-and-api-updates
 
     Args:
         generated_outputs: The model generated output(s) to evaluate

--- a/src/langcheck/metrics/ja/reference_based_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_based_text_quality.py
@@ -27,9 +27,7 @@ def semantic_similarity(
     the reference outputs. The similarities are computed as the cosine
     similarities between the generated and reference embeddings. This metric
     takes on float values between [-1, 1], but typically ranges between 0 and 1
-    where 0 is minimum similarity and 1 is maximum similarity. (NOTE: when using
-    OpenAI embeddings, the cosine similarities tend to be skewed quite heavily
-    towards higher numbers.)
+    where 0 is minimum similarity and 1 is maximum similarity.
 
     We currently support three embedding model types:
 

--- a/src/langcheck/metrics/ja/reference_based_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_based_text_quality.py
@@ -37,7 +37,7 @@ def semantic_similarity(
     is downloaded from HuggingFace and run locally. This is the default model
     type and there is no setup needed to run this.
 
-    2. The 'openai' type, where we use OpenAI's 'text-embedding-ada-002' model
+    2. The 'openai' type, where we use OpenAI's 'text-embedding-3-small' model
     by default (this is configurable). See
     `this page <https://langcheck.readthedocs.io/en/latest/metrics.html
     #computing-metrics-with-openai-models>`__


### PR DESCRIPTION
This PR updates the default embedding model for `semantic_similarity` from `text-embedding-ada-002` to `text-embedding-3-small`.

OpenAI [announced](https://openai.com/blog/new-embedding-models-and-api-updates) new embedding models last week, and the new model `text-embedding-3-small` worked better than the old one `text-embedding-ada-002` for my use cases.
(The reduced price is another strong point for the new model.)

Especially, although `text-embedding-ada-002` had an issue: the cosine similarities tend to be skewed quite heavily towards higher numbers ([as commented in docs](https://langcheck.readthedocs.io/en/latest/langcheck.metrics.ja.reference_based_text_quality.html#langcheck.metrics.ja.reference_based_text_quality.semantic_similarity)), new model `text-embedding-3-small` seems to resolve this issue.

The another new model `text-embedding-3-large` is not good for the _default_ model, because of the increased price.

### Supplemental data
Here is the result of my test cases(Japanese):

|LLM answer (dummy)|Reference|Similarity (Local: paraphrase-multilingual-mpnet-base-v2)|Similarity (OpenAI: text-embedding-ada-002)|Similarity (OpenAI: text-embedding-3-small)|
| -- | -- | -- | -- | -- |
|メロスは激怒した。| メロスは激怒した。|1.000000| 1.000000|1.000000|
|メロスは激しく怒った。| メロスは激怒した。|0.980329| 0.990486|0.965431|
|メロスは、激しく、怒った。| メロスは激しく怒った|0.961034| 0.976309|0.947357|
|セリヌンティウスは待っていた。| メロスは激怒した。|0.250888|0.817479|0.237152|
|単語のベクトル表現は、1960年代における情報検索用のベクトル空間モデルを元に開発された。潜在的意味分析は、特異値分解で次元数を削減することで、1980年代後半に導入された。|単語をベクトルとして表現する手法は、1960年代における情報検索用のベクトル空間モデルの開発が元になっている。特異値分解を使用して次元数を削減することにより、1980年代後半に潜在的意味分析が導入された。|0.979269|0.986894|0.934140|
|1960年以前に、ベクトル表現は開発された。のちに次元数を増幅することにより、潜在分析が導入された。|単語をベクトルとして表現する手法は、1960年代における情報検索用のベクトル空間モデルの開発が元になっている。特異値分解を使用して次元数を削減することにより、1980年代後半に潜在的意味分析が導入された。|0.649559|0.906195|0.709959|
|すみません、ITヘルプデスクに電話で問い合わせてください。|大変申し訳ございませんが、弊社情報部門のヘルプデスクにメールでお問い合わせください。|0.768630|0.930722|0.752877|

Test script [here](https://github.com/bioerrorlog/python-examples/tree/main/langcheck_sandbox), or see [my writeup (Japanese)](https://www.bioerrorlog.work/entry/langcheck-llm-evaluation#%E8%A3%9C%E8%B6%B3-semantic_similarity%E3%81%A7Embedding%E3%83%A2%E3%83%87%E3%83%AB%E3%82%92%E6%8C%87%E5%AE%9A%E3%81%99%E3%82%8B).

Thank you.