### PR TITLE
Update Japanese prompts to return assessments in English

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,10 @@ jobs:
           pip install --upgrade pip
           pip install .[dev]
 
+      - name: Check Disk Space
+        run: |
+          df -h
+
       # Run integration tests
       - name: Test
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,8 +31,19 @@ jobs:
           pip install --upgrade pip
           pip install .[dev]
 
-      - name: Check Disk Space
+      # Remove unneeded system libraries to maximize disk space
+      # https://github.com/easimon/maximize-build-space/blob/master/action.yml
+      # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+      - name: Maximize disk space
         run: |
+          echo "Available disk space (before):"
+          df -h
+
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/lib/android
+
+          echo "Available disk space (after):"
           df -h
 
       # Run integration tests

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -511,10 +511,10 @@ def answer_relevance(
 
         ユーザーの質問に対して回答が関連性のあるものかどうかを判断してください。利用可能な評価
         は以下の通りです:
-        `完全に関連` - 回答はユーザーの質問に完全に関連し、十分に答えています。
-        `部分的に関連` - 回答はユーザーの質問に部分的に関連していますが、質問に完全に答えて
+        `Fully Relevant` - 回答はユーザーの質問に完全に関連し、十分に答えています。
+        `Partially Relevant` - 回答はユーザーの質問に部分的に関連していますが、質問に完全に答えて
         いないか、関連しない情報が含まれています。
-        `関連なし` - 回答はユーザーの質問に関連していない、または質問に適切に対応していません。
+        `Not Relevant` - 回答はユーザーの質問に関連していない、または質問に適切に対応していません。
 
         深呼吸をして、この問題をステップバイステップで取り組んでください。
         '''
@@ -527,15 +527,15 @@ def answer_relevance(
         ************
 
         結果として出た評価を保存してください。利用可能な評価は以下の通りです:
-        `完全に関連`
-        `部分的に関連`
-        `関連なし`
+        `Fully Relevant`
+        `Partially Relevant`
+        `Not Relevant`
         '''
 
     answer_relevance_assessment_to_score = {
-        '完全に関連': 1.0,
-        '部分的に関連': 0.5,
-        '関連なし': 0.0
+        'Fully Relevant': 1.0,
+        'Partially Relevant': 0.5,
+        'Not Relevant': 0.0
     }
     oai_evaluator = OpenAIBasedEvaluator(
         assessment_to_score_mapping=answer_relevance_assessment_to_score,

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -175,11 +175,11 @@ def context_relevance(
 
         ユーザーの質問に対応するために必要な、関連性のある情報がソースに含まれているかを判断
         してください。利用可能な評価は以下の通りです:
-        `完全に関連` - ソーステキストには、ユーザーの質問に対応するために必要な情報が
+        `Fully Relevant` - ソーステキストには、ユーザーの質問に対応するために必要な情報が
         含まれています。
-        `部分的に関連` - ソーステキストはユーザーの質問に部分的に関連していますが、質問に
+        `Partially Relevant` - ソーステキストはユーザーの質問に部分的に関連していますが、質問に
         対応するために必要なすべての情報を含んでいません。
-        `関連なし` - ソーステキストはユーザーの質問に関連していません。
+        `Not Relevant` - ソーステキストはユーザーの質問に関連していません。
 
         深呼吸をして、この問題をステップバイステップで取り組んでください。
         '''
@@ -192,15 +192,15 @@ def context_relevance(
         ************
 
         結果として出た評価を保存してください。利用可能な評価は以下の通りです:
-        `完全に関連`
-        `部分的に関連`
-        `関連なし`
+        `Fully Relevant`
+        `Partially Relevant`
+        `Not Relevant`
         '''
 
     context_relevance_assessment_to_score = {
-        '完全に関連': 1.0,
-        '部分的に関連': 0.5,
-        '関連なし': 0.0
+        'Fully Relevant': 1.0,
+        'Partially Relevant': 0.5,
+        'Not Relevant': 0.0
     }
     oai_evaluator = OpenAIBasedEvaluator(
         assessment_to_score_mapping=context_relevance_assessment_to_score,

--- a/tests/metrics/ja/test_reference_free_text_quality.py
+++ b/tests/metrics/ja/test_reference_free_text_quality.py
@@ -145,7 +145,7 @@ def test_answer_relevance_openai(generated_outputs, prompts):
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [
         Mock(message=Mock(function_call=Mock(
-            arguments="{\n  \"answer_relevance\": \"完全に関連\"\n}")))
+            arguments="{\n  \"answer_relevance\": \"Fully Relevant\"\n}")))
     ]
 
     # Calling the openai.resources.chat.Completions.create method requires an
@@ -157,7 +157,7 @@ def test_answer_relevance_openai(generated_outputs, prompts):
         metric_value = answer_relevance(generated_outputs,
                                         prompts,
                                         model_type='openai')
-        # "完全に関連" gets a value of 1.0
+        # "Fully Relevant" gets a value of 1.0
         assert metric_value == 1
 
         # Set the necessary env vars for the 'azure_openai' model type
@@ -168,5 +168,5 @@ def test_answer_relevance_openai(generated_outputs, prompts):
                                         prompts,
                                         model_type='azure_openai',
                                         openai_args={'model': 'foo bar'})
-        # "完全に関連" gets a value of 1.0
+        # "Fully Relevant" gets a value of 1.0
         assert metric_value == 1

--- a/tests/metrics/ja/test_source_based_text_quality.py
+++ b/tests/metrics/ja/test_source_based_text_quality.py
@@ -67,7 +67,7 @@ def test_context_relevance_openai(prompts, sources):
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [
         Mock(message=Mock(function_call=Mock(
-            arguments="{\n  \"context_relevance\": \"完全に関連\"\n}")))
+            arguments="{\n  \"context_relevance\": \"Fully Relevant\"\n}")))
     ]
 
     # Calling the openai.resources.chat.Completions.create method requires an
@@ -77,7 +77,7 @@ def test_context_relevance_openai(prompts, sources):
         # Set the necessary env vars for the 'openai' model type
         os.environ["OPENAI_API_KEY"] = "dummy_key"
         metric_value = context_relevance(prompts, sources, model_type='openai')
-        # "完全に関連" gets a value of 1.0
+        # "Fully Relevant" gets a value of 1.0
         assert metric_value == 1
 
         # Set the necessary env vars for the 'azure_openai' model type
@@ -88,5 +88,5 @@ def test_context_relevance_openai(prompts, sources):
                                          sources,
                                          model_type='azure_openai',
                                          openai_args={'model': 'foo bar'})
-        # "完全に関連" gets a value of 1.0
+        # "Fully Relevant" gets a value of 1.0
         assert metric_value == 1


### PR DESCRIPTION
It seems like OpenAI's function calling models sometimes struggles to return Japanese phrases reliably. E.g. here's an example where the returned value for `answer_relevance` was complete nonsense 🤨 
![image](https://github.com/citadel-ai/langcheck/assets/107823399/71ecbd9a-18a8-4744-8736-1cc4d6c11036)

Updating the assessments to English makes things much more stable!

Also added a "Maximize disk space" step to pytest.yml because it kept running out of disk space.