### PR TITLE
Add pip install tests for different Python versions

### DIFF
--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -15,8 +15,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false  # Continue running jobs even if another fails
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -12,12 +12,16 @@ on:
 jobs:
   # This workflow contains a single job called "pip_install"
   pip_install:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    # Define the matrix of environments to test installation on
     strategy:
       fail-fast: false  # Continue running jobs even if another fails
       matrix:
+        # We specify Python versions as strings so 3.10 doesn't become 3.1
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
+
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -20,6 +20,14 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-14]
 
+        # GitHub Actions doesn't support Python 3.8 and 3.9 on M1 macOS yet:
+        # https://github.com/actions/setup-python/issues/696
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            version: "3.9"
+
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install MeCab (if necessary)
-        if: ${{ matrix.os }} == 'ubuntu-latest' && ${{ matrix.python-version }} == '3.12'
+        if: ${{ matrix.os  == 'ubuntu-latest' && matrix.python-version  == '3.12' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y mecab libmecab-dev mecab-ipadic-utf8

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -23,10 +23,10 @@ jobs:
         # GitHub Actions doesn't support Python 3.8 and 3.9 on M1 macOS yet:
         # https://github.com/actions/setup-python/issues/696
         exclude:
-          - os: macos-latest
-            python-version: "3.8"
-          - os: macos-latest
-            version: "3.9"
+          - python-version: "3.8"
+            os: macos-14
+          - python-version: "3.9"
+            os: macos-14
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -41,6 +41,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install MeCab (if necessary)
+        if: {{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mecab libmecab-dev mecab-ipadic-utf8
+
       - name: Install Core LangCheck
         run: |
           pip install --upgrade pip

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install MeCab (if necessary)
-        if: {{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        if: ${{ matrix.os }} == 'ubuntu-latest' && ${{ matrix.python-version }} == '3.12'
         run: |
           sudo apt-get update
           sudo apt-get install -y mecab libmecab-dev mecab-ipadic-utf8

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # We specify Python versions as strings so 3.10 doesn't become 3.1
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -27,7 +27,7 @@ jobs:
             os: macos-14
           - python-version: "3.9"
             os: macos-14
-          # TODO: We need to manually install MeCab on Windows to install
+          # TODO: Figure out how to install MeCab on Windows to install
           # LangCheck on Python 3.12 since there are no wheels for `fugashi`
           - python-version: "3.12"
             os: windows-latest
@@ -45,12 +45,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # We need to manually install MeCab on Ubuntu to install LangCheck on
+      # Python 3.12 since there are no wheels for `fugashi`
       - name: Install MeCab on Ubuntu (if necessary)
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y mecab libmecab-dev mecab-ipadic-utf8
 
+      # We need to manually install MeCab on macOS to install LangCheck on
+      # Python 3.12 since there are no wheels for `fugashi`
       - name: Install MeCab on macOS (if necessary)
         if: ${{ matrix.os == 'macos-14' && matrix.python-version == '3.12' }}
         run: |
@@ -65,3 +69,7 @@ jobs:
       - name: Install Core LangCheck with Optional Dependencies
         run: |
           pip install .[optional]
+
+      - name: Import LangCheck
+        run: |
+          python -c "import langcheck"

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -20,13 +20,17 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-14]
 
-        # GitHub Actions doesn't support Python 3.8 and 3.9 on M1 macOS yet:
-        # https://github.com/actions/setup-python/issues/696
         exclude:
+          # GitHub Actions doesn't support Python 3.8 and 3.9 on M1 macOS yet:
+          # https://github.com/actions/setup-python/issues/696
           - python-version: "3.8"
             os: macos-14
           - python-version: "3.9"
             os: macos-14
+          # TODO: We need to manually install MeCab on Windows to install
+          # LangCheck on Python 3.12 since there are no wheels for `fugashi`
+          - python-version: "3.12"
+            os: windows-latest
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -1,4 +1,4 @@
-name: Pytest Tests
+name: Pip Install Matrix
 
 # Controls when the workflow will run
 on:
@@ -10,33 +10,29 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "pytest"
-  pytest:
+  # This workflow contains a single job called "pip_install"
+  pip_install:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks out this repository so this job can access it
       - uses: actions/checkout@v4
 
-      # Use Python 3.8.16
-      - uses: actions/setup-python@v5
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
 
-      # Install the langcheck package with dev dependencies
-      - name: Install
+      - name: Install Core LangCheck
         run: |
           pip install --upgrade pip
-          pip install .[dev]
+          pip install .
 
-      # Run integration tests
-      - name: Test
-        run: |
-          python -m pytest -s -vv --durations=0 -m "not optional"
-
-      - name: Test (Optional)
+      - name: Install Core LangCheck with Optional Dependencies
         run: |
           pip install .[optional]
-          python -m pytest -s -vv --durations=0 -m "optional"

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -41,29 +41,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: test1
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: |
-          echo ${{ matrix.os }}
-          echo ${{ matrix.os == 'ubuntu-latest' }}
-
-      - name: test2
-        if: ${{ matrix.python-version == '3.12' }}
-        run: |
-          echo ${{ matrix.python-version }}
-          echo ${{ matrix.python-version == '3.12' }}
-
-      - name: test3
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
-        run: |
-          echo ${{ matrix.os }}
-          echo ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
-
-      - name: Install MeCab (if necessary)
+      - name: Install MeCab on Ubuntu (if necessary)
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y mecab libmecab-dev mecab-ipadic-utf8
+
+      - name: Install MeCab on macOS (if necessary)
+        if: ${{ matrix.os == 'macos-14' && matrix.python-version == '3.12' }}
+        run: |
+          brew update
+          brew install mecab
 
       - name: Install Core LangCheck
         run: |

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -41,8 +41,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: test1
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          echo ${{ matrix.os }}
+          echo ${{ matrix.os == 'ubuntu-latest' }}
+
+      - name: test2
+        if: ${{ matrix.python-version == '3.12' }}
+        run: |
+          echo ${{ matrix.python-version }}
+          echo ${{ matrix.python-version == '3.12' }}
+
+      - name: test3
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        run: |
+          echo ${{ matrix.os }}
+          echo ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+
       - name: Install MeCab (if necessary)
-        if: ${{ matrix.os  == 'ubuntu-latest' && matrix.python-version  == '3.12' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y mecab libmecab-dev mecab-ipadic-utf8

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,19 @@ jobs:
           pip install --upgrade pip
           pip install .[dev]
 
+      # Remove unneeded system libraries to maximize disk space
+      # https://github.com/easimon/maximize-build-space/blob/master/action.yml
+      # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+      - name: Maximize disk space
+        run: |
+          echo "Available disk space (before):"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/lib/android
+          echo "Available disk space (after):"
+          df -h
+
       # Run integration tests
       - name: Test
         run: |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Simple, Pythonic building blocks to evaluate LLM applications.
 pip install langcheck
 ```
 
+Having installation issues? [See the FAQ](https://langcheck.readthedocs.io/en/latest/installation.html#installation-faq).
+
 ## Examples
 
 ### Evaluate Text

--- a/README_ja.md
+++ b/README_ja.md
@@ -26,6 +26,8 @@ LLMアプリケーションの評価のためのシンプルなPythonライブ�
 pip install langcheck
 ```
 
+インストールがうまくいかない場合、[FAQ(英語)](https://langcheck.readthedocs.io/en/latest/installation.html#installation-faq)もご覧ください。
+
 ## 利用例
 
 ### テキスト評価

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,4 +12,41 @@ LangCheck works with Python 3.8 or higher.
 Model files are lazily downloaded the first time you run a metric function. For example, the first time you run the ``langcheck.metrics.sentiment()`` function, LangCheck will automatically download the Twitter-roBERTa-base model.
 :::
 
-To install LangCheck directly from the repository source, see [the Contributing page](contributing.md).
+To install LangCheck from source, see [the Contributing page](contributing.md).
+
+## Installation FAQ
+
+Depending on your environment, you might need to install additional system libraries for `pip install langcheck` to work.
+
+If you have any problems installing LangCheck, please check the FAQ below or [open an issue on GitHub](https://github.com/citadel-ai/langcheck/issues).
+
+### 1. Installing LangCheck with Python 3.12
+
+As of February 2024, one of LangCheck's Japanese dependencies, [`fugashi`](https://github.com/polm/fugashi), doesn't provide wheels for Python 3.12, so you'll need to first install MeCab for pip to successfully build `fugashi`.
+
+**Installing MeCab on Linux (Debian/Ubuntu)**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y mecab libmecab-dev mecab-ipadic-utf8
+```
+
+**Installing MeCab on macOS**
+
+```bash
+brew install mecab
+```
+
+**Installing MeCab on Windows**
+
+We haven't tested LangCheck on Windows with Python 3.12, but it may work if you install MeCab with [the official installer](https://taku910.github.io/mecab/#install).
+
+### 2. The error message `command 'gcc' failed`
+
+As of February 2024, one of LangCheck's Japanese dependencies, [`dartsclone`](https://github.com/s-yata/darts-clone), doesn't provide wheels for Python 3.10+. You'll need to have `gcc` installed for pip to successfully build `dartsclone`.
+
+Most systems already have `gcc` installed, with the exception of "slim" Docker images such as [`python:3.11-slim-buster`](https://hub.docker.com/_/python). If you're using this image, you can:
+
+1. Use `python:3.11-buster` instead of `python:3.11-slim-buster`, which includes gcc.
+1. Run `apt update && apt install build-essential -y` (e.g. in your Dockerfile) to install gcc.
+


### PR DESCRIPTION
This PR adds GitHub Actions to test installing LangCheck on this combination of environments:

```
        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
        os: [ubuntu-latest, windows-latest, macos-14]
```

It also adds a "Installation FAQ" in the documentation with instructions on how to fix some issues we've seen.