### PR TITLE
Add the tqdm progress bar to more metrics

### DIFF
--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -131,12 +131,20 @@ def _sentiment_local(generated_outputs: List[str]) -> List[float]:
                                         return_tensors='pt',
                                         padding=True)
 
+    batch_size = 8
+    scores = []
     with torch.no_grad():
-        # Probabilities of [negative, neutral, positive]
-        probs = torch.nn.functional.softmax(
-            _sentiment_model(**input_tokens).logits, dim=1)
-
-    return (probs[:, 1] / 2 + probs[:, 2]).tolist()
+        for i in tqdm_wrapper(range(0, len(generated_outputs), batch_size),
+                              total=(len(generated_outputs) + batch_size - 1) //
+                              batch_size):
+            batch_input_tokens = {
+                k: v[i:i + batch_size] for k, v in input_tokens.items()
+            }
+            # Probabilities of [negative, neutral, positive]
+            probs = torch.nn.functional.softmax(
+                _sentiment_model(**batch_input_tokens).logits, dim=1)
+            scores.extend((probs[:, 1] / 2 + probs[:, 2]).tolist())
+    return scores
 
 
 def _sentiment_openai(

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -116,12 +116,19 @@ def sentiment(
                                         return_tensors='pt',
                                         padding=True)
 
+    batch_size = 8
+    scores = []
     with torch.no_grad():
-        # Probabilities of [negative, neutral, positive]
-        probs = torch.nn.functional.softmax(
-            _sentiment_model(**input_tokens).logits, dim=1)
-
-    scores = (probs[:, 1] / 2 + probs[:, 2]).tolist()
+        for i in tqdm_wrapper(range(0, len(generated_outputs), batch_size),
+                              total=(len(generated_outputs) + batch_size - 1) //
+                              batch_size):
+            batch_input_tokens = {
+                k: v[i:i + batch_size] for k, v in input_tokens.items()
+            }
+            # Probabilities of [negative, neutral, positive]
+            probs = torch.nn.functional.softmax(
+                _sentiment_model(**batch_input_tokens).logits, dim=1)
+            scores.extend((probs[:, 1] / 2 + probs[:, 2]).tolist())
 
     return MetricValue(metric_name='sentiment',
                        prompts=prompts,


### PR DESCRIPTION
Found that `sentiment` for all `en`, `ja`. `de` were missing the tqdm progress bar so added that.

For non-english factual consistency metrics, if the user puts a lot of text, entire pipeline seems stopping because no progress bar is shown.  I also added the progress bar to those translation steps to resolve that.