### PR TITLE
Change input of `OpenAIBasedEvaluator.get_score()` from str to `Iterable[str]`

### DIFF
--- a/src/langcheck/metrics/de/reference_free_text_quality.py
+++ b/src/langcheck/metrics/de/reference_free_text_quality.py
@@ -216,15 +216,10 @@ def _sentiment_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
 
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    return scores, explanations
 
 
 def fluency(
@@ -391,15 +386,10 @@ def _fluency_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
 
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    return scores, explanations
 
 
 def toxicity(
@@ -577,14 +567,10 @@ def _toxicity_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
+
+    return scores, explanations
 
 
 def flesch_kincaid_grade(
@@ -789,21 +775,14 @@ def answer_relevance(
         client=openai_client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for gen, user_query in tqdm_wrapper(zip(generated_outputs, prompts),
-                                        desc='Calculating scores',
-                                        total=len(prompts)):
-        score, explanation = oai_evaluator.get_score(_prompt(gen, user_query),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs, prompts), _function_call_prompt)
 
     return MetricValue(metric_name='answer_relevance',
                        prompts=prompts,
                        generated_outputs=generated_outputs,
                        reference_outputs=None,
                        sources=None,
-                       explanations=explanation_list,
-                       metric_values=score_list,
+                       explanations=explanations,
+                       metric_values=scores,
                        language=LANG)

--- a/src/langcheck/metrics/de/source_based_text_quality.py
+++ b/src/langcheck/metrics/de/source_based_text_quality.py
@@ -213,17 +213,10 @@ def _factual_consistency_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, sources, generated_outputs), _function_call_prompt)
 
-    explanation_list = []
-    for src, gen in tqdm_wrapper(zip(sources, generated_outputs),
-                                 desc='Calculating scores',
-                                 total=len(generated_outputs)):
-        score, explanation = oai_evaluator.get_score(
-            _prompt(src=src, gen_output=gen), _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    return scores, explanations
 
 
 def context_relevance(
@@ -321,21 +314,14 @@ def context_relevance(
         client=openai_client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for src, user_query in tqdm_wrapper(zip(sources, prompts),
-                                        desc='Calculating scores',
-                                        total=len(prompts)):
-        score, explanation = oai_evaluator.get_score(
-            _prompt(src=src, user_query=user_query), _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, sources, prompts), _function_call_prompt)
 
     return MetricValue(metric_name='context_relevance',
                        prompts=prompts,
                        generated_outputs=None,
                        reference_outputs=None,
                        sources=sources,
-                       explanations=explanation_list,
-                       metric_values=score_list,
+                       explanations=explanations,
+                       metric_values=scores,
                        language=LANG)

--- a/src/langcheck/metrics/en/_openai.py
+++ b/src/langcheck/metrics/en/_openai.py
@@ -100,7 +100,6 @@ class OpenAIBasedEvaluator:
         # First, call the API to get an unstructured assessment. The response
         # should include both the assessment itself and the model's reasoning
         # for that assessment.
-        # Call the API to get an unstructured assessments.
         config_unstructured_assessments = {
             "model": "gpt-3.5-turbo",
             "seed": 123
@@ -168,8 +167,7 @@ class OpenAIBasedEvaluator:
                                         in self._assessment_to_score_mapping):
                 continue
             # By leveraging the function calling API, this should be pretty
-            # rare, but we're dealing with LLMs here so nothing is
-            # absolute!
+            # rare, but we're dealing with LLMs here so nothing is absolute!
             print(f'OpenAI returned an unrecognized assessment: "{assessment}"')
 
         return [

--- a/src/langcheck/metrics/en/_openai.py
+++ b/src/langcheck/metrics/en/_openai.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable
 from typing import Any
 
 from openai import AzureOpenAI, OpenAI
@@ -66,7 +66,7 @@ class OpenAIBasedEvaluator:
 
     def get_score(
         self,
-        prompts: str | Iterator[str] | Sequence[str],
+        prompts: str | Iterable[str],
         function_call_prompt_template: Callable,
     ) -> tuple[list[float | None], list[str | None]]:
         '''
@@ -177,7 +177,7 @@ class OpenAIBasedEvaluator:
             if assessment else None for assessment in assessments
         ], unstructured_assessments
 
-    def _call_api(self, prompts: Iterator[str | None] | Sequence[str | None],
+    def _call_api(self, prompts: Iterable[str | None],
                   config: dict[str, str]) -> list[Any]:
         # Generates input dict for API call. This procedure is separated as a
         # method because yapf fails when there are too much nests.

--- a/src/langcheck/metrics/en/_openai.py
+++ b/src/langcheck/metrics/en/_openai.py
@@ -1,8 +1,11 @@
 import json
 import os
-from typing import Callable, Dict, Optional, Tuple
+from typing import (Any, Callable, Dict, Iterator, List, Optional, Sequence,
+                    Tuple)
 
 from openai import AzureOpenAI, OpenAI
+
+from langcheck.utils.progess_bar import tqdm_wrapper
 
 
 class OpenAIBasedEvaluator:
@@ -61,8 +64,10 @@ class OpenAIBasedEvaluator:
         self._openai_args = openai_args
 
     def get_score(
-        self, prompt: str, function_call_prompt_template: Callable
-    ) -> Tuple[Optional[float], Optional[str]]:
+        self,
+        prompts: Iterator[str] | Sequence[str],
+        function_call_prompt_template: Callable,
+    ) -> Tuple[List[float | None], List[str | None]]:
         '''
         Retrieves the score and unstructured assessment for a given prompt using
         the OpenAI API. The first API call is a "normal" call, where the API
@@ -73,46 +78,47 @@ class OpenAIBasedEvaluator:
         assessment.
 
         Args:
-            prompt: Prompt that asks the OpenAI API for the unstructured
-                assessment response
+            prompts: :List of prompt that asks the OpenAI API for the
+                unstructured assessment response
             function_call_prompt_template: Prompt template used to construct the
                 prompt that asks the OpenAI API for the structured assessment
                 response
 
         Returns:
-            score: score associated with the given prompt based on the resulting
-                structured assessment. Returns `None` if the score could not be
-                computed.
-            unstructured_assessment: unstructured assessment text, which also
-                serves as the explanation of the score. Returns `None` if the
-                score could not be computed.
+            scores: List of scores associated with the corresponding prompts
+                based on the resulting structured assessment. If a score cannot
+                be computed for a prompt, it will be represented as `None`.
+            unstructured_assessments: List of unstructured assessment text,
+                which also serves as the explanation of the score. If a score
+                cannot be computed for a prompt, it will be represented as
+                `None`.
         '''
         # First, call the API to get an unstructured assessment. The response
         # should include both the assessment itself and the model's reasoning
         # for that assessment.
-        messages = [{"role": "user", "content": prompt}]
-        try:
-            if self._openai_args is None:
-                response = self._client.chat.completions.create(
-                    model="gpt-3.5-turbo", seed=123,
-                    messages=messages)  # type: ignore
-            else:
-                response = self._client.chat.completions.create(
-                    messages=messages,  # type: ignore
-                    seed=123,
-                    **self._openai_args)  # type: ignore
-            unstructured_assessment = response.choices[0].message.content
-        except Exception as e:
-            print(f'OpenAI failed to return an unstructured assessment: {e}')
-            print(f'Prompt that triggered the failure is:\n{prompt}')
-            return None, None
+        # Call the API to get an unstructured assessments.
+        config_unstructured_assessments = {
+            "model": "gpt-3.5-turbo",
+            "seed": 123
+        }
+        config_unstructured_assessments.update(self._openai_args or {})
+
+        responses = self._call_api(prompts=prompts,
+                                   config=config_unstructured_assessments)
+        unstructured_assessments = [
+            response.choices[0].message.content if response else None
+            for response in responses
+        ]
 
         # Next, call the API leveraging function calling to get a structured
-        # assessment
-        fn_call_messages = [{
-            "role": "user",
-            "content": function_call_prompt_template(unstructured_assessment)
-        }]
+        # assessment.
+        # Construct the prompt for the function calling API, filled with None
+        # for the failed unstructured assessment.
+        fn_call_messages = [
+            function_call_prompt_template(unstructured_assessment)
+            if unstructured_assessment else None
+            for unstructured_assessment in unstructured_assessments
+        ]
         argument_options = list(self._assessment_to_score_mapping.keys())
         functions = [{
             "name": self._function_name,
@@ -129,38 +135,72 @@ class OpenAIBasedEvaluator:
                 "required": [self._argument_name],
             },
         }]
-        try:
-            if self._openai_args is None:
-                response = self._client.chat.completions.create(
-                    model="gpt-3.5-turbo",
-                    messages=fn_call_messages,  # type: ignore
-                    seed=123,
-                    functions=functions,  # type: ignore
-                    function_call={"name": self._function_name})
-            else:
-                response = self._client.chat.completions.create(  # type: ignore
-                    messages=fn_call_messages,  # type: ignore
-                    seed=123,
-                    functions=functions,  # type: ignore
-                    function_call={"name": self._function_name},
-                    **self._openai_args)  # type: ignore
-            # For type checking
-            assert response.choices[0].message.function_call is not None
-            function_args = json.loads(
-                response.choices[0].message.function_call.arguments)
-            assessment = function_args.get(self._argument_name)
-        except Exception as e:
-            print(f'OpenAI failed to return a structured assessment: {e}')
-            print('Prompt that triggered the failure is:\n'
-                  f'{function_call_prompt_template(unstructured_assessment)}')
-            return None, None
+        config_structured_assessments = {
+            "seed": 123,
+            "functions": functions,
+            "function_call": {
+                "name": self._function_name
+            },
+            "model": "gpt-3.5-turbo"
+        }
+        config_structured_assessments.update(self._openai_args or {})
 
-        if assessment not in self._assessment_to_score_mapping:
+        responses = self._call_api(
+            prompts=fn_call_messages,
+            config=config_structured_assessments,
+        )
+        function_args = [
+            json.loads(response.choices[0].message.function_call.arguments)
+            if response else None for response in responses
+        ]
+        assessments = [
+            function_arg.get(self._argument_name) if function_arg else None
+            for function_arg in function_args
+        ]
+
+        # Check if any of the assessments are not recognized.
+        for assessment in assessments:
+            if (assessment is None) or (assessment
+                                        in self._assessment_to_score_mapping):
+                continue
             # By leveraging the function calling API, this should be pretty
-            # rare, but we're dealing with LLMs here so nothing is absolute!
+            # rare, but we're dealing with LLMs here so nothing is
+            # absolute!
             print(f'OpenAI returned an unrecognized assessment: "{assessment}"')
-            print(f'Prompt that triggered the failure is:\n{prompt}')
-            return None, None
 
-        return self._assessment_to_score_mapping[
-            assessment], unstructured_assessment
+        return [
+            self._assessment_to_score_mapping[assessment]
+            if assessment else None for assessment in assessments
+        ], unstructured_assessments
+
+    def _call_api(self, prompts: Iterator[str | None] | Sequence[str | None],
+                  config: Dict[str, str]) -> List[Any]:
+        # Generates input dict for API call. This procedure is separated as a
+        # method because yapf fails when there are too much nests.
+        def _generate_model_input(prompt: str | None) -> Dict[str, Any]:
+            return {"messages": [{"role": "user", "content": prompt}], **config}
+
+        # A helper function to call the API with exception filter for alignment
+        # of exception handling with the async version.
+        def _call_api_with_exception_filter(model_input: Dict[str, Any]) -> Any:
+            if model_input is None:
+                return None
+            try:
+                return self._client.chat.completions.create(**model_input)
+            except Exception as e:
+                return e
+
+        model_inputs = map(_generate_model_input, prompts)
+        responses = [
+            _call_api_with_exception_filter(model_input)
+            for model_input in tqdm_wrapper(model_inputs)
+        ]
+
+        # Filter out exceptions and print them out.
+        for i, response in enumerate(responses):
+            if not isinstance(response, Exception):
+                continue
+            print('OpenAI failed to return an assessment corresponding to '
+                  f'{i}th prompt: {response}')
+            responses[i] = None
+        return responses

--- a/src/langcheck/metrics/en/_openai.py
+++ b/src/langcheck/metrics/en/_openai.py
@@ -65,7 +65,7 @@ class OpenAIBasedEvaluator:
 
     def get_score(
         self,
-        prompts: Iterator[str] | Sequence[str],
+        prompts: str | Iterator[str] | Sequence[str],
         function_call_prompt_template: Callable,
     ) -> Tuple[List[float | None], List[str | None]]:
         '''
@@ -93,6 +93,9 @@ class OpenAIBasedEvaluator:
                 cannot be computed for a prompt, it will be represented as
                 `None`.
         '''
+        if isinstance(prompts, str):
+            prompts = [prompts]
+
         # First, call the API to get an unstructured assessment. The response
         # should include both the assessment itself and the model's reasoning
         # for that assessment.

--- a/src/langcheck/metrics/en/_openai.py
+++ b/src/langcheck/metrics/en/_openai.py
@@ -6,8 +6,7 @@ from collections.abc import Callable, Iterator, Sequence
 from typing import Any
 
 from openai import AzureOpenAI, OpenAI
-
-from langcheck.utils.progess_bar import tqdm_wrapper
+from tqdm import tqdm
 
 
 class OpenAIBasedEvaluator:
@@ -198,7 +197,7 @@ class OpenAIBasedEvaluator:
         model_inputs = map(_generate_model_input, prompts)
         responses = [
             _call_api_with_exception_filter(model_input)
-            for model_input in tqdm_wrapper(model_inputs)
+            for model_input in tqdm(model_inputs)
         ]
 
         # Filter out exceptions and print them out.

--- a/src/langcheck/metrics/en/_openai.py
+++ b/src/langcheck/metrics/en/_openai.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import os
-from typing import (Any, Callable, Dict, Iterator, List, Optional, Sequence,
-                    Tuple)
+from collections.abc import Callable, Iterator, Sequence
+from typing import Any
 
 from openai import AzureOpenAI, OpenAI
 
@@ -11,11 +13,11 @@ from langcheck.utils.progess_bar import tqdm_wrapper
 class OpenAIBasedEvaluator:
     '''Evaluator class based on OpenAI's API.'''
 
-    def __init__(self, assessment_to_score_mapping: Dict[str, float],
+    def __init__(self, assessment_to_score_mapping: dict[str, float],
                  function_name: str, function_description: str,
                  argument_name: str, argument_description: str,
-                 client_type: str, client: Optional[OpenAI],
-                 openai_args: Optional[Dict[str, str]]) -> None:
+                 client_type: str, client: OpenAI | None,
+                 openai_args: dict[str, str] | None) -> None:
         '''
         Initialize the OpenAIBasedEvaluator with given parameters.
 
@@ -67,7 +69,7 @@ class OpenAIBasedEvaluator:
         self,
         prompts: str | Iterator[str] | Sequence[str],
         function_call_prompt_template: Callable,
-    ) -> Tuple[List[float | None], List[str | None]]:
+    ) -> tuple[list[float | None], list[str | None]]:
         '''
         Retrieves the score and unstructured assessment for a given prompt using
         the OpenAI API. The first API call is a "normal" call, where the API
@@ -177,15 +179,15 @@ class OpenAIBasedEvaluator:
         ], unstructured_assessments
 
     def _call_api(self, prompts: Iterator[str | None] | Sequence[str | None],
-                  config: Dict[str, str]) -> List[Any]:
+                  config: dict[str, str]) -> list[Any]:
         # Generates input dict for API call. This procedure is separated as a
         # method because yapf fails when there are too much nests.
-        def _generate_model_input(prompt: str | None) -> Dict[str, Any]:
+        def _generate_model_input(prompt: str | None) -> dict[str, Any]:
             return {"messages": [{"role": "user", "content": prompt}], **config}
 
         # A helper function to call the API with exception filter for alignment
         # of exception handling with the async version.
-        def _call_api_with_exception_filter(model_input: Dict[str, Any]) -> Any:
+        def _call_api_with_exception_filter(model_input: dict[str, Any]) -> Any:
             if model_input is None:
                 return None
             try:

--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -202,15 +202,10 @@ def _sentiment_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
 
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    return scores, explanations
 
 
 def fluency(
@@ -398,15 +393,10 @@ def _fluency_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
 
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    return scores, explanations
 
 
 def toxicity(
@@ -581,14 +571,10 @@ def _toxicity_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
+
+    return scores, explanations
 
 
 def flesch_reading_ease(
@@ -815,21 +801,14 @@ def answer_relevance(
         client=openai_client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for gen, user_query in tqdm_wrapper(zip(generated_outputs, prompts),
-                                        desc='Calculating scores',
-                                        total=len(prompts)):
-        score, explanation = oai_evaluator.get_score(_prompt(gen, user_query),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs, prompts), _function_call_prompt)
 
     return MetricValue(metric_name='answer_relevance',
                        prompts=prompts,
                        generated_outputs=generated_outputs,
                        reference_outputs=None,
                        sources=None,
-                       explanations=explanation_list,
-                       metric_values=score_list,
+                       explanations=explanations,
+                       metric_values=scores,
                        language='en')

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -296,17 +296,10 @@ def _factual_consistency_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, sources, generated_outputs), _function_call_prompt)
 
-    explanation_list = []
-    for src, gen in tqdm_wrapper(zip(sources, generated_outputs),
-                                 desc='Calculating scores',
-                                 total=len(generated_outputs)):
-        score, explanation = oai_evaluator.get_score(
-            _prompt(src=src, gen_output=gen), _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    return scores, explanations
 
 
 def context_relevance(
@@ -401,21 +394,14 @@ def context_relevance(
         client=openai_client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for src, user_query in tqdm_wrapper(zip(sources, prompts),
-                                        desc='Calculating scores',
-                                        total=len(prompts)):
-        score, explanation = oai_evaluator.get_score(
-            _prompt(src=src, user_query=user_query), _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, sources, prompts), _function_call_prompt)
 
     return MetricValue(metric_name='context_relevance',
                        prompts=prompts,
                        generated_outputs=None,
                        reference_outputs=None,
                        sources=sources,
-                       explanations=explanation_list,
-                       metric_values=score_list,
+                       explanations=explanations,
+                       metric_values=scores,
                        language='en')

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -198,15 +198,10 @@ def _sentiment_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
 
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    return scores, explanations
 
 
 def toxicity(
@@ -395,14 +390,10 @@ def _toxicity_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
+
+    return scores, explanations
 
 
 def fluency(
@@ -593,15 +584,9 @@ def _fluency_openai(
         client=client,
         openai_args=openai_args)
 
-    score_list = []
-
-    explanation_list = []
-    for gen in tqdm_wrapper(generated_outputs):
-        score, explanation = oai_evaluator.get_score(_prompt(gen_output=gen),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
-    return score_list, explanation_list
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs), _function_call_prompt)
+    return scores, explanations
 
 
 def tateishi_ono_yamada_reading_ease(
@@ -772,21 +757,14 @@ def answer_relevance(
         client=openai_client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for gen, user_query in tqdm_wrapper(zip(generated_outputs, prompts),
-                                        desc='Calculating scores',
-                                        total=len(prompts)):
-        score, explanation = oai_evaluator.get_score(_prompt(gen, user_query),
-                                                     _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, generated_outputs, prompts), _function_call_prompt)
 
     return MetricValue(metric_name='answer_relevance',
                        prompts=prompts,
                        generated_outputs=generated_outputs,
                        reference_outputs=None,
                        sources=None,
-                       explanations=explanation_list,
-                       metric_values=score_list,
+                       explanations=explanations,
+                       metric_values=scores,
                        language='ja')

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -228,21 +228,14 @@ def context_relevance(
         client=openai_client,
         openai_args=openai_args)
 
-    score_list = []
-    explanation_list = []
-    for src, user_query in tqdm_wrapper(zip(sources, prompts),
-                                        desc='Calculating scores',
-                                        total=len(prompts)):
-        score, explanation = oai_evaluator.get_score(
-            _prompt(src=src, user_query=user_query), _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
+    scores, explanations = oai_evaluator.get_score(
+        map(_prompt, sources, prompts), _function_call_prompt)
 
     return MetricValue(metric_name='context_relevance',
                        prompts=prompts,
                        generated_outputs=None,
                        reference_outputs=None,
                        sources=sources,
-                       explanations=explanation_list,
-                       metric_values=score_list,
+                       explanations=explanations,
+                       metric_values=scores,
                        language='ja')


### PR DESCRIPTION
## Motivation
First step to enable async API call of OpenAI API.

## Details
This PR allows `OpenAIBasedEvaluator.get_score()` to take Iterable[str] in addition to `str`, which enables metrics functions to pass prompt at once.