### PR TITLE
Pairwise comparison metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,6 +47,7 @@ LangCheck metrics are categorized by metric type, which correspond to the kind o
 | [Reference-Based Text Quality Metrics](#reference-based-text-quality-metrics) | `semantic_similarity(generated_outputs, reference_outputs)`<br>`rouge2(generated_outputs, reference_outputs)`    | EN, JA, DE        |
 | [Source-Based Text Quality Metrics](#source-based-text-quality-metrics)       | `factual_consistency(generated_outputs, sources)`                                                                | EN, JA, DE        |
 | [Text Structure Metrics](#text-structure-metrics)                             | `is_float(generated_outputs, min=0, max=None)`<br>`is_json_object(generated_outputs)`                            | All Languages |
+| [Pairwise Text Quality Metrics](#pairwise-text-quality-metrics) | `pairwise_comparison(generated_outputs_a, generated_outputs_b, prompts)` | EN |
 
 (reference-free-text-quality-metrics)=
 ### Reference-Free Text Quality Metrics
@@ -75,6 +76,13 @@ An example metric is {func}`~langcheck.metrics.en.source_based_text_quality.fact
 Text structure metrics validate the format of the text (e.g. is the text valid JSON, an email address, an integer in a specified range). Compared to other metric types which can return floats, these metrics only return 0 or 1.
 
 An example metric is {func}`~langcheck.metrics.text_structure.is_json_object`, which checks if the LLM-generated text is a valid JSON object.
+
+(pairwise-text-quality-metrics)=
+### Pairwise Text Quality Metrics
+
+Pairwise metrics require two generated outputs (A and B) and the corresponding prompt. The reference output and source text are also optional inputs.
+
+An example metric is {func}`~langcheck.metrics.en.pairwise_text_quality.pairwise_comparison`, which compares the quality of two generated outputs (`generated_outputs_a` and `generated_outputs_a`) in response to the given prompt. If a reference output and/or source text are provided, those are also taken into consideration to judge the quality of the outputs. The scores are either 0.0 (Response A is better), 0.5 (Tie), or 1.0 (Response B is better).
 
 (computing-metrics-with-openai-models)=
 ### Computing Metrics with OpenAI Models

--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -1,4 +1,5 @@
 from langcheck.metrics import de, en, ja, zh
+from langcheck.metrics.en.pairwise_text_quality import pairwise_comparison
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.en.reference_free_text_quality import (
@@ -36,6 +37,7 @@ __all__ = [
     'is_json_array',
     'is_json_object',
     'matches_regex',
+    'pairwise_comparison',
     'rouge1',
     'rouge2',
     'rougeL',

--- a/src/langcheck/metrics/_validation.py
+++ b/src/langcheck/metrics/_validation.py
@@ -170,6 +170,39 @@ def validate_parameters_answer_relevance(
     return generated_outputs, prompts
 
 
+def validate_parameters_pairwise_comparison(
+    generated_outputs_a: List[str] | str, generated_outputs_b: List[str] | str,
+    prompts: List[str] | str, sources_a: Optional[List[str] | str],
+    sources_b: Optional[List[str] | str],
+    reference_outputs: Optional[List[str] | str]
+) -> tuple[List[str], List[str], List[str], Optional[List[str]],
+           Optional[List[str]], Optional[List[str]]]:
+    '''Validates and parses function parameters for the pairwise comparison
+    metric.
+
+    Args:
+        generated_outputs_a: Model A's generated output(s) to evaluate
+        generated_outputs_b: Model B's generated output(s) to evaluate
+        prompts: The prompts used to generate the output(s).
+        sources_a: (Optional) the source(s) of Model A's generated output(s)
+        sources_b: (Optional) the source(s) of Model B's generated output(s)
+        reference_outputs: (Optional) the reference output(s)
+
+    Returns:
+        A tuple (generated_outputs_a, generated_outputs_b, prompts,
+        sources_a, sources_b, reference_outputs) of the parsed parameters. All
+        non-None parameters are converted to lists of strings.
+    '''
+    _generated_outputs_a, _prompts, _reference_outputs, _sources_a = _validate_parameters(  # NOQA: E501
+        generated_outputs_a, prompts, reference_outputs, sources_a)
+    _generated_outputs_b, _, _, _sources_b = _validate_parameters(
+        generated_outputs_b, None, None, sources_b)
+    # For type checking
+    assert _prompts is not None
+    return (_generated_outputs_a, _generated_outputs_b, _prompts, _sources_a,
+            _sources_b, _reference_outputs)
+
+
 def _validate_parameters(
     generated_outputs: List[str] | str, prompts: Optional[List[str] | str],
     reference_outputs: Optional[List[str] | str],

--- a/src/langcheck/metrics/en/__init__.py
+++ b/src/langcheck/metrics/en/__init__.py
@@ -1,3 +1,4 @@
+from langcheck.metrics.en.pairwise_text_quality import pairwise_comparison
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.en.reference_free_text_quality import (
@@ -14,6 +15,7 @@ __all__ = [
     'flesch_kincaid_grade',
     'flesch_reading_ease',
     'fluency',
+    'pairwise_comparison',
     'rouge1',
     'rouge2',
     'rougeL',

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -7,18 +7,21 @@ from openai import OpenAI
 from langcheck.metrics._validation import \
     validate_parameters_pairwise_comparison
 from langcheck.metrics.en._openai import OpenAIBasedEvaluator
+from langcheck.metrics.metric_value import MetricValue
 from langcheck.utils.progess_bar import tqdm_wrapper
 
 
-def pairwise_comparison(generated_outputs_a: List[str] | str,
-                        generated_outputs_b: List[str] | str,
-                        prompts: List[str] | str,
-                        sources_a: Optional[List[str] | str] = None,
-                        sources_b: Optional[List[str] | str] = None,
-                        reference_outputs: Optional[List[str] | str] = None,
-                        model_type: str = 'openai',
-                        openai_client: Optional[OpenAI] = None,
-                        openai_args: Optional[Dict[str, str]] = None) -> None:
+def pairwise_comparison(
+    generated_outputs_a: List[str] | str,
+    generated_outputs_b: List[str] | str,
+    prompts: List[str] | str,
+    sources_a: Optional[List[str] | str] = None,
+    sources_b: Optional[List[str] | str] = None,
+    reference_outputs: Optional[List[str] | str] = None,
+    model_type: str = 'openai',
+    openai_client: Optional[OpenAI] = None,
+    openai_args: Optional[Dict[str,
+                               str]] = None) -> MetricValue[Optional[float]]:
     generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b, reference_outputs = validate_parameters_pairwise_comparison(  # NOQA: E501
         generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b,
         reference_outputs)
@@ -216,5 +219,12 @@ def pairwise_comparison(generated_outputs_a: List[str] | str,
         score_list.append(score)
         explanation_list.append(explanation)
 
-    print(score_list)
-    print(explanation_list)
+    return MetricValue(metric_name='pairwise_comparison',
+                       prompts=prompts,
+                       generated_outputs=(generated_outputs_a,
+                                          generated_outputs_b),
+                       reference_outputs=reference_outputs,
+                       sources=(sources_a, sources_b),
+                       explanations=explanation_list,
+                       metric_values=score_list,
+                       language='en')

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional
 
 from openai import OpenAI
 
+from langcheck.metrics._validation import \
+    validate_parameters_pairwise_comparison
 from langcheck.metrics.en._openai import OpenAIBasedEvaluator
 from langcheck.utils.progess_bar import tqdm_wrapper
 
@@ -11,12 +13,15 @@ from langcheck.utils.progess_bar import tqdm_wrapper
 def pairwise_comparison(generated_outputs_a: List[str] | str,
                         generated_outputs_b: List[str] | str,
                         prompts: List[str] | str,
-                        sources_a: Optional[List[str]] = None,
-                        sources_b: Optional[List[str]] = None,
-                        reference_outputs: Optional[List[str]] = None,
+                        sources_a: Optional[List[str] | str] = None,
+                        sources_b: Optional[List[str] | str] = None,
+                        reference_outputs: Optional[List[str] | str] = None,
                         model_type: str = 'openai',
                         openai_client: Optional[OpenAI] = None,
                         openai_args: Optional[Dict[str, str]] = None) -> None:
+    generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b, reference_outputs = validate_parameters_pairwise_comparison(  # NOQA: E501
+        generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b,
+        reference_outputs)
     assert model_type in [
         'openai', 'azure_openai'
     ], ('Unsupported model type. '

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -139,6 +139,10 @@ def pairwise_comparison(
         # If a score is not consistent, set it to None, and merge the two
         # explanations to show the inconsistency.
         for i in range(len(score_list)):
+            if score_list[i] is None or swapped_score_list[i] is None:
+                # If either score is None, we cannot determine consistency, so
+                # we just keep the original score and explanation
+                continue
             if score_list[i] + swapped_score_list[i] != 1.0:
                 score_list[i] = None
                 explanation_list[

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -108,7 +108,7 @@ def pairwise_comparison(
 
     score_list = []
     explanation_list = []
-    prompt_fn, data_iter = _construct_pairwise_comparison_data(
+    prompt_fn, data_iter = _construct_pairwise_comparison_prompt_and_data(
         generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b,
         reference_outputs)
     for data_instance in tqdm_wrapper(data_iter,
@@ -123,7 +123,7 @@ def pairwise_comparison(
         # Swap the generated outputs and calculate the scores again
         swapped_score_list = []
         swapped_explanation_list = []
-        prompt_fn, swapped_data_iter = _construct_pairwise_comparison_data(
+        prompt_fn, swapped_data_iter = _construct_pairwise_comparison_prompt_and_data(  # NOQA: E501
             generated_outputs_b, generated_outputs_a, prompts, sources_b,
             sources_a, reference_outputs)
         for swapped_data_instance in tqdm_wrapper(
@@ -159,7 +159,7 @@ def pairwise_comparison(
                        language='en')
 
 
-def _construct_pairwise_comparison_data(
+def _construct_pairwise_comparison_prompt_and_data(
         generated_outputs_1: List[str], generated_outputs_2: List[str],
         prompts: List[str], sources_1: Optional[List[str]],
         sources_2: Optional[List[str]], reference_outputs: Optional[List[str]]

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from openai import OpenAI
+
+from langcheck.metrics.en._openai import OpenAIBasedEvaluator
+from langcheck.utils.progess_bar import tqdm_wrapper
+
+
+def pairwise_comparison(generated_outputs_a: List[str] | str,
+                        generated_outputs_b: List[str] | str,
+                        prompts: List[str] | str,
+                        model_type: str = 'openai',
+                        openai_client: Optional[OpenAI] = None,
+                        openai_args: Optional[Dict[str, str]] = None) -> None:
+    assert model_type in [
+        'openai', 'azure_openai'
+    ], ('Unsupported model type. '
+        'The supported ones are ["openai", "azure_openai"]')
+
+    def _prompt(gen_output_a: str, gen_output_b: str, user_query: str) -> str:
+        return f'''
+        You are comparing the quality of two responses to a user's query. Here
+        is the data:
+        [BEGIN DATA]
+        ************
+        [User Query]: {user_query}
+        ************
+        [Response A]: {gen_output_a}
+        ************
+        [Response B]: {gen_output_b}
+        ************
+        [END DATA]
+
+        Determine which of the responses is a better response to the user's
+        query. Consider factors such as helpfulness, correctness, and relevance
+        in your assessment. Do not allow the order in which the responses were
+        presented to influence your assessment. Do not allow the length of the
+        responses to influence your assessment. The available assessments are:
+        `Response A` - Response A is a better response.
+        `Response B` - Response B is a better response.
+        `Tie` - The two responses are roughly equal in quality.
+
+        Take a deep breath and work on this problem step-by-step.
+        '''
+
+    def _function_call_prompt(long_assessment: str) -> str:
+        return f'''
+        The following is an assessment on whether Response A or Response B is
+        the better response to the user's query:
+        ************
+        [Assessment]: {long_assessment}
+        ************
+
+        Save the resulting assessment. The available assessments are:
+        `Response A`
+        `Response B`
+        `Tie`
+        '''
+
+    pairwise_comparison_assessment_to_score = {
+        'Response B': 1.0,
+        'Tie': 0.5,
+        'Response A': 0.0
+    }
+    oai_evaluator = OpenAIBasedEvaluator(
+        assessment_to_score_mapping=pairwise_comparison_assessment_to_score,
+        function_name='save_pairwise_comparison_assessment',
+        function_description=("Saves a pairwise comparison assessment."),
+        argument_name='pairwise_comparison',
+        argument_description='The pairwise comparison assessment',
+        client_type=model_type,
+        client=openai_client,
+        openai_args=openai_args)
+
+    score_list = []
+    explanation_list = []
+    for gen_a, gen_b, user_query in tqdm_wrapper(zip(generated_outputs_a,
+                                                     generated_outputs_b,
+                                                     prompts),
+                                                 desc='Calculating scores',
+                                                 total=len(prompts)):
+        score, explanation = oai_evaluator.get_score(
+            _prompt(gen_a, gen_b, user_query), _function_call_prompt)
+        score_list.append(score)
+        explanation_list.append(explanation)
+
+    print(score_list)
+    print(explanation_list)

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -141,7 +141,9 @@ def pairwise_comparison(
         for i in range(len(score_list)):
             if score_list[i] is None or swapped_score_list[i] is None:
                 # If either score is None, we cannot determine consistency, so
-                # we just keep the original score and explanation
+                # we set the score and explanation to None
+                score_list[i] = None
+                explanation_list[i] = None
                 continue
             if score_list[i] + swapped_score_list[i] != 1.0:
                 score_list[i] = None

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -11,6 +11,7 @@ from langcheck.utils.progess_bar import tqdm_wrapper
 def pairwise_comparison(generated_outputs_a: List[str] | str,
                         generated_outputs_b: List[str] | str,
                         prompts: List[str] | str,
+                        reference_outputs: Optional[List[str]] = None,
                         model_type: str = 'openai',
                         openai_client: Optional[OpenAI] = None,
                         openai_args: Optional[Dict[str, str]] = None) -> None:
@@ -38,6 +39,37 @@ def pairwise_comparison(generated_outputs_a: List[str] | str,
         in your assessment. Do not allow the order in which the responses were
         presented to influence your assessment. Do not allow the length of the
         responses to influence your assessment. The available assessments are:
+        `Response A` - Response A is a better response.
+        `Response B` - Response B is a better response.
+        `Tie` - The two responses are roughly equal in quality.
+
+        Take a deep breath and work on this problem step-by-step.
+        '''
+
+    def _prompt_with_reference(gen_output_a: str, gen_output_b: str,
+                               user_query: str, ref_output: str) -> str:
+        return f'''
+        You are comparing the quality of two responses to a user's query. The
+        ideal response to the user's query is also provided to you as a
+        reference. Here is the data:
+        [BEGIN DATA]
+        ************
+        [Ideal Response]: {ref_output}
+        ************
+        [User Query]: {user_query}
+        ************
+        [Response A]: {gen_output_a}
+        ************
+        [Response B]: {gen_output_b}
+        ************
+        [END DATA]
+
+        Determine which of the responses is a better response to the user's
+        query. Consider factors such as helpfulness, correctness, and relevance
+        in your assessment, using the provided Ideal Response as a reference. Do
+        not allow the order in which the responses were presented to influence
+        your assessment. Do not allow the length of the responses to influence
+        your assessment. The available assessments are:
         `Response A` - Response A is a better response.
         `Response B` - Response B is a better response.
         `Tie` - The two responses are roughly equal in quality.
@@ -76,15 +108,26 @@ def pairwise_comparison(generated_outputs_a: List[str] | str,
 
     score_list = []
     explanation_list = []
-    for gen_a, gen_b, user_query in tqdm_wrapper(zip(generated_outputs_a,
-                                                     generated_outputs_b,
-                                                     prompts),
-                                                 desc='Calculating scores',
-                                                 total=len(prompts)):
-        score, explanation = oai_evaluator.get_score(
-            _prompt(gen_a, gen_b, user_query), _function_call_prompt)
-        score_list.append(score)
-        explanation_list.append(explanation)
+    if reference_outputs is not None:
+        for gen_a, gen_b, user_query, ref in tqdm_wrapper(
+                zip(generated_outputs_a, generated_outputs_b, prompts,
+                    reference_outputs),
+                desc='Calculating scores',
+                total=len(prompts)):
+            score, explanation = oai_evaluator.get_score(
+                _prompt_with_reference(gen_a, gen_b, user_query, ref),
+                _function_call_prompt)
+            score_list.append(score)
+            explanation_list.append(explanation)
+    else:
+        for gen_a, gen_b, user_query in tqdm_wrapper(zip(
+                generated_outputs_a, generated_outputs_b, prompts),
+                                                     desc='Calculating scores',
+                                                     total=len(prompts)):
+            score, explanation = oai_evaluator.get_score(
+                _prompt(gen_a, gen_b, user_query), _function_call_prompt)
+            score_list.append(score)
+            explanation_list.append(explanation)
 
     print(score_list)
     print(explanation_list)

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -22,6 +22,48 @@ def pairwise_comparison(
     openai_client: Optional[OpenAI] = None,
     openai_args: Optional[Dict[str,
                                str]] = None) -> MetricValue[Optional[float]]:
+    '''Calculates the pairwise comparison metric. This metric takes on float
+    values of either 0.0 (Response A is better), 0.5 (Tie), or 1.0 (Response B
+    is better). The score may also be `None` if it could not be computed.
+
+    We currently support two model types:
+
+    1. The 'openai' type, where we use OpenAI's 'gpt-turbo-3.5' model
+    by default. While the model you use is configurable, please make sure to use
+    one that supports function calling
+    (https://platform.openai.com/docs/guides/gpt/function-calling). See
+    `this page <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
+    for examples on setting up the OpenAI API key.
+
+    2. The 'azure_openai' type. Essentially the same as the 'openai' type,
+    except that it uses the AzureOpenAI client. Note that you must specify your
+    model deployment to use in ``openai_args``, e.g.
+    ``openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}``
+
+    Ref:
+        Our prompt is similar to the prompt used in
+        https://arxiv.org/abs/2306.05685
+
+    Args:
+        generated_outputs_a: Model A's generated output(s) to evaluate
+        generated_outputs_b: Model B's generated output(s) to evaluate
+        prompts: The prompts used to generate the output(s)
+        sources_a: The source text(s) for Model A's generated output(s), default
+            None
+        sources_b: The source text(s) for Model B's generated output(s), default
+            None
+        reference_outputs: The reference output(s), default None
+        model_type: The type of model to use ('openai', or 'azure_openai'),
+            default 'openai'
+        openai_client: OpenAI or AzureOpenAI client, default None. If this is
+            None, we will attempt to create a default client.
+        openai_args: Dict of additional args to pass in to the
+            ``client.chat.completions.create`` function, default None
+
+    Returns:
+        An MetricValue object
+    '''
     generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b, reference_outputs = validate_parameters_pairwise_comparison(  # NOQA: E501
         generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b,
         reference_outputs)

--- a/src/langcheck/metrics/metric_value.py
+++ b/src/langcheck/metrics/metric_value.py
@@ -31,10 +31,12 @@ class MetricValue(Generic[NumericType]):
 
     def to_df(self) -> pd.DataFrame:
         '''Returns a DataFrame of metric values for each data point.'''
-        if isinstance(self.generated_outputs, tuple):
-            # Pairwise metric
+        if self.is_pairwise:
+            # For type checking
+            assert self.generated_outputs is not None
             generated_outputs_a, generated_outputs_b = self.generated_outputs
-            sources_a, sources_b = self.sources if self.sources else (None, None)
+            sources_a, sources_b = self.sources if self.sources else (None,
+                                                                      None)
             dataframe_cols = {
                 'prompt': self.prompts,
                 'source_a': sources_a,
@@ -146,7 +148,6 @@ class MetricValue(Generic[NumericType]):
         This is a convenience function that calls
         :func:`langcheck.plot.scatter()`.
         '''
-
         from langcheck.plot import scatter as plot_scatter
 
         # Type ignore because a Self type is only valid in class contexts
@@ -167,6 +168,10 @@ class MetricValue(Generic[NumericType]):
         return plot_histogram(
             self,  # type: ignore[reportGeneralTypeIssues]
             jupyter_mode=jupyter_mode)
+
+    @property
+    def is_pairwise(self) -> bool:
+        return isinstance(self.generated_outputs, tuple)
 
 
 @dataclass

--- a/src/langcheck/metrics/metric_value.py
+++ b/src/langcheck/metrics/metric_value.py
@@ -19,23 +19,41 @@ class MetricValue(Generic[NumericType]):
     metric_name: str
     metric_values: List[NumericType]
     prompts: Optional[List[str]]
-    generated_outputs: Optional[List[str]]
+    # Generated outputs are a tuple for pairwise metrics
+    generated_outputs: Optional[List[str] | tuple[List[str], List[str]]]
     reference_outputs: Optional[List[str]]
-    sources: Optional[List[str]]
-    explanations: Optional[List[Optional[
-        str]]]  # An explanation can be None if the metric could not be computed
+    # Sources are a tuple for pairwise metrics (if available)
+    sources: Optional[List[str] |
+                      tuple[Optional[List[str]], Optional[List[str]]]]
+    # An explanation can be None if the metric could not be computed
+    explanations: Optional[List[Optional[str]]]
     language: Optional[str]
 
     def to_df(self) -> pd.DataFrame:
         '''Returns a DataFrame of metric values for each data point.'''
-        dataframe_cols = {
-            'prompt': self.prompts,
-            'source': self.sources,
-            'generated_output': self.generated_outputs,
-            'reference_output': self.reference_outputs,
-            'explanation': self.explanations,
-            'metric_value': self.metric_values,
-        }
+        if isinstance(self.generated_outputs, tuple):
+            # Pairwise metric
+            generated_outputs_a, generated_outputs_b = self.generated_outputs
+            sources_a, sources_b = self.sources if self.sources else (None, None)
+            dataframe_cols = {
+                'prompt': self.prompts,
+                'source_a': sources_a,
+                'source_b': sources_b,
+                'generated_output_a': generated_outputs_a,
+                'generated_output_b': generated_outputs_b,
+                'reference_output': self.reference_outputs,
+                'explanation': self.explanations,
+                'metric_value': self.metric_values,
+            }
+        else:
+            dataframe_cols = {
+                'prompt': self.prompts,
+                'source': self.sources,
+                'generated_output': self.generated_outputs,
+                'reference_output': self.reference_outputs,
+                'explanation': self.explanations,
+                'metric_value': self.metric_values,
+            }
 
         return pd.DataFrame(dataframe_cols)
 

--- a/src/langcheck/plot/_scatter.py
+++ b/src/langcheck/plot/_scatter.py
@@ -30,6 +30,11 @@ def scatter(metric_value: MetricValue,
             Dash documentation for more info:
             https://dash.plotly.com/workspaces/using-dash-in-jupyter-and-workspaces#display-modes
     '''
+    if metric_value.is_pairwise or (other_metric_value is not None and
+                                    other_metric_value.is_pairwise):
+        raise NotImplementedError(
+            'Scatter plots for pairwise MetricValues are not supported yet')
+
     if other_metric_value is None:
         _scatter_one_metric_value(metric_value, jupyter_mode)
     else:

--- a/tests/metrics/en/test_pairwise_text_quality.py
+++ b/tests/metrics/en/test_pairwise_text_quality.py
@@ -1,0 +1,74 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from openai.types.chat import ChatCompletion
+
+from langcheck.metrics.en.pairwise_text_quality import pairwise_comparison
+
+################################################################################
+# Tests
+################################################################################
+
+
+@pytest.mark.parametrize(
+    'generated_outputs_a,generated_outputs_b,prompts,sources_a,sources_b,reference_outputs',  # NOQA: E501
+    [("Tokyo is Japan's capital city.", "New York is Japan's capital city.",
+      'What is the capital of Japan?', None, None, None),
+     ("Tokyo is Japan's capital city.", "New York is Japan's capital city.",
+      'What is the capital of Japan?', None, None, 'Tokyo'),
+     ("Tokyo is Japan's capital city.", "New York is Japan's capital city.",
+      'What is the capital of Japan?', 'Capital of Japan = Tokyo', None, None),
+     ("Tokyo is Japan's capital city.", "New York is Japan's capital city.",
+      'What is the capital of Japan?', 'Capital of Japan = Tokyo',
+      'Capital of Japan = Tokyo', None),
+     ("Tokyo is Japan's capital city.", "New York is Japan's capital city.",
+      'What is the capital of Japan?', 'Capital of Japan = Tokyo',
+      'Capital of Japan = Tokyo', 'Tokyo')])
+def test_pairwise_comparison_openai(generated_outputs_a, generated_outputs_b,
+                                    prompts, sources_a, sources_b,
+                                    reference_outputs):
+    '''Test the pairwise_comparison function.
+
+    Test 1: No sources or reference outputs are provided.
+    Test 2: Reference output is provided.
+    Test 3: Source A is provided.
+    Test 4: Both Source A and Source B are provided.
+    Test 5: Source A, Source B, and the reference output are provided.
+    '''
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(function_call=Mock(
+            arguments="{\n  \"pairwise_comparison\": \"Response A\"\n}")))
+    ]
+
+    # Calling the openai.resources.chat.Completions.create method requires an
+    # OpenAI API key, so we mock the return value instead
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='openai')
+        # "Response A" gets a value of 0
+        assert metric_value == 0
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='azure_openai',
+                                           openai_args={'model': 'foo bar'})
+        # "Response A" gets a value of 0
+        assert metric_value == 0

--- a/tests/metrics/en/test_pairwise_text_quality.py
+++ b/tests/metrics/en/test_pairwise_text_quality.py
@@ -72,3 +72,55 @@ def test_pairwise_comparison_openai(generated_outputs_a, generated_outputs_b,
                                            openai_args={'model': 'foo bar'})
         # "Tie" gets a value of 0.5
         assert metric_value == 0.5
+
+
+@pytest.mark.parametrize(
+    'generated_outputs_a,generated_outputs_b,prompts,sources_a,sources_b,reference_outputs',  # NOQA: E501
+    [("Tokyo is Japan's capital city.", "New York is Japan's capital city.",
+      'What is the capital of Japan?', None, None, None)])
+def test_pairwise_comparison_inconsistency_openai(generated_outputs_a,
+                                                  generated_outputs_b, prompts,
+                                                  sources_a, sources_b,
+                                                  reference_outputs):
+    '''Test the pairwise_comparison function when inconsistent scores are
+    returned when Model A and Model B are swapped.
+    '''
+    # If Response A is selected for both the original order (Model A vs. Model
+    # B) and the swapped order (Model B vs. Model A), then the results are
+    # inconsistent.
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(function_call=Mock(
+            arguments="{\n  \"pairwise_comparison\": \"Response A\"\n}")))
+    ]
+
+    # Calling the openai.resources.chat.Completions.create method requires an
+    # OpenAI API key, so we mock the return value instead
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='openai')
+        # The score should be None if the results are inconsistent
+        assert metric_value.metric_values[0] is None
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='azure_openai',
+                                           openai_args={'model': 'foo bar'})
+        # The score should be None if the results are inconsistent
+        assert metric_value.metric_values[0] is None

--- a/tests/metrics/en/test_pairwise_text_quality.py
+++ b/tests/metrics/en/test_pairwise_text_quality.py
@@ -39,7 +39,7 @@ def test_pairwise_comparison_openai(generated_outputs_a, generated_outputs_b,
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [
         Mock(message=Mock(function_call=Mock(
-            arguments="{\n  \"pairwise_comparison\": \"Response A\"\n}")))
+            arguments="{\n  \"pairwise_comparison\": \"Tie\"\n}")))
     ]
 
     # Calling the openai.resources.chat.Completions.create method requires an
@@ -55,8 +55,8 @@ def test_pairwise_comparison_openai(generated_outputs_a, generated_outputs_b,
                                            sources_b=sources_b,
                                            reference_outputs=reference_outputs,
                                            model_type='openai')
-        # "Response A" gets a value of 0
-        assert metric_value == 0
+        # "Tie" gets a value of 0.5
+        assert metric_value == 0.5
 
         # Set the necessary env vars for the 'azure_openai' model type
         os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
@@ -70,5 +70,5 @@ def test_pairwise_comparison_openai(generated_outputs_a, generated_outputs_b,
                                            reference_outputs=reference_outputs,
                                            model_type='azure_openai',
                                            openai_args={'model': 'foo bar'})
-        # "Response A" gets a value of 0
-        assert metric_value == 0
+        # "Tie" gets a value of 0.5
+        assert metric_value == 0.5

--- a/tests/metrics/test_metric_value.py
+++ b/tests/metrics/test_metric_value.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import pandas as pd
 import pytest
 
 from langcheck.metrics import is_float
@@ -74,3 +75,26 @@ def test_optional_metric_values():
     assert (metric_value > 0).pass_rate == 0.5
     assert (metric_value == 1).pass_rate == 0.5
     assert (metric_value == 0).pass_rate == 0
+
+
+def test_pairwise_metric_value():
+    score_list = [1.0, 0.0]
+    dummy_generated_outputs_a = ['foo', 'bar']
+    dummy_generated_outputs_b = ['baz', 'bat']
+    metric_value = MetricValue(metric_name='test',
+                               prompts=None,
+                               generated_outputs=(dummy_generated_outputs_a,
+                                                  dummy_generated_outputs_b),
+                               reference_outputs=None,
+                               sources=None,
+                               explanations=None,
+                               metric_values=score_list,
+                               language='en')
+
+    metric_value_df = metric_value.to_df()
+    assert metric_value_df['generated_output_a'].equals(
+        pd.Series(dummy_generated_outputs_a))
+    assert metric_value_df['generated_output_b'].equals(
+        pd.Series(dummy_generated_outputs_b))
+    assert metric_value_df['source_a'].equals(pd.Series([None, None]))
+    assert metric_value_df['source_b'].equals(pd.Series([None, None]))

--- a/tests/metrics/test_text_structure.py
+++ b/tests/metrics/test_text_structure.py
@@ -34,6 +34,7 @@ def test_is_int(generated_outputs, domain, metric_values):
     assert metric_value.metric_name == 'is_int'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -62,6 +63,7 @@ def test_is_float(generated_outputs, min, max, metric_values):
     assert metric_value.metric_name == 'is_float'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -84,6 +86,7 @@ def test_is_json_array(generated_outputs, metric_values):
     assert metric_value.metric_name == 'is_json_array'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -106,6 +109,7 @@ def test_is_json_object(generated_outputs, metric_values):
     assert metric_value.metric_name == 'is_json_object'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -140,6 +144,7 @@ def test_matches_regex(generated_outputs, regex, metric_values):
     assert metric_value.metric_name == 'matches_regex'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -170,6 +175,7 @@ def test_contains_regex(generated_outputs, regex, metric_values):
     assert metric_value.metric_name == 'contains_regex'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -216,6 +222,7 @@ def test_contains_all_strings(generated_outputs, strings, case_sensitive,
     assert metric_value.metric_name == 'contains_all_strings'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -262,6 +269,7 @@ def test_contains_any_strings(generated_outputs, strings, case_sensitive,
     assert metric_value.metric_name == 'contains_any_strings'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)
 
@@ -279,5 +287,6 @@ def test_validation_fn(generated_outputs, valid_fn, metric_values):
     assert metric_value.metric_name == 'validation_fn'
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
+    assert isinstance(metric_value.generated_outputs, list)
     assert lists_are_equal(generated_outputs, metric_value.generated_outputs)
     assert is_close(metric_value.metric_values, metric_values)


### PR DESCRIPTION
Implements the pairwise comparison metric. The required inputs are the two generated outputs and the prompt, but you can also input the source and the reference output. E.g. here's an example of how to use the metric:
```
prompts = ['what is langcheck?']
gen_a = ['langcheck tool for checking the quality of language']
gen_b = ['langcheck python package for evaluating LLM applications']
source = ['LangCheck is a simple, Pythonic toolkit to evaluate LLM applications - use it to create unit tests, monitoring, guardrails, and more. Get started with the docs below.']
reference = ['LangCheck is a Python package for evaluating and monitoring LLM applications, developed by Citadel AI']

# Reference and source b
langcheck.metrics.pairwise_comparison(gen_a,
                                      gen_b,
                                      prompts,
                                      reference_outputs=reference,
                                      sources_b=source,
                                      model_type='azure_openai',
                                      openai_args=openai_args)
```
<img width="1683" alt="image" src="https://github.com/citadel-ai/langcheck/assets/107823399/1387869e-e637-4165-87c1-dd8cc7f0d327">


By default, the metric is computed twice (once with Model A vs. Model B and once with the order swapped, i.e. Model B vs. Model A). If the metric result is not consistent for the two, we set the score to be `None` and populate the `explanation` with both of the assessments for reference.