### PR TITLE
Support asynchronous API call of `OpenAIBasedEvaluator.get_score()`

### DIFF
--- a/src/langcheck/metrics/de/reference_free_text_quality.py
+++ b/src/langcheck/metrics/de/reference_free_text_quality.py
@@ -26,14 +26,14 @@ _translation_model_path = 'Helsinki-NLP/opus-mt-de-en'
 LANG = 'de'
 
 
-def sentiment(
-        generated_outputs: List[str] | str,
-        prompts: Optional[List[str] | str] = None,
-        model_type: str = 'local',
-        openai_client: Optional[OpenAI] = None,
-        openai_args: Optional[Dict[str, str]] = None,
-        local_overflow_strategy: str = 'truncate'
-) -> MetricValue[Optional[float]]:
+def sentiment(generated_outputs: List[str] | str,
+              prompts: Optional[List[str] | str] = None,
+              model_type: str = 'local',
+              openai_client: Optional[OpenAI] = None,
+              openai_args: Optional[Dict[str, str]] = None,
+              local_overflow_strategy: str = 'truncate',
+              *,
+              use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the sentiment scores of generated outputs. This metric takes
     on float values between [0, 1], where 0 is negative sentiment and 1 is
     positive sentiment. (NOTE: when using the OpenAI model, the sentiment scores
@@ -91,8 +91,11 @@ def sentiment(
         'The supported ones are ["local", "openai", "azure_openai"]')
 
     if model_type == 'openai' or model_type == 'azure_openai':
-        scores, explanations = _sentiment_openai(generated_outputs, model_type,
-                                                 openai_client, openai_args)
+        scores, explanations = _sentiment_openai(generated_outputs,
+                                                 model_type,
+                                                 openai_client,
+                                                 openai_args,
+                                                 use_async=use_async)
     else:
         scores = _sentiment_local(generated_outputs, local_overflow_strategy)
         explanations = None
@@ -136,12 +139,13 @@ def _sentiment_local(generated_outputs: List[str],
 
 
 def _sentiment_openai(
-        generated_outputs: List[str],
-        client_type: str,
-        client: Optional[OpenAI],
-        openai_args: Optional[Dict[str, str]],
-        *,
-        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+    generated_outputs: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
+) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the sentiment scores and their associated explanations of
     generated outputs using the OpenAI API. This metric takes on float values
     that are either 0, 0.5, or 1, where 0 is negative sentiment, 0.5 is neutral
@@ -226,13 +230,13 @@ def _sentiment_openai(
     return scores, explanations
 
 
-def fluency(
-    generated_outputs: List[str] | str,
-    prompts: Optional[List[str] | str] = None,
-    model_type: str = 'local',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def fluency(generated_outputs: List[str] | str,
+            prompts: Optional[List[str] | str] = None,
+            model_type: str = 'local',
+            openai_client: Optional[OpenAI] = None,
+            openai_args: Optional[Dict[str, str]] = None,
+            *,
+            use_async: bool = False) -> MetricValue[Optional[float]]:
     ''' Calculates the fluency scores of generated outputs. This metric takes on
     float values between [0, 1], where 0 is low fluency and 1 is high fluency.
     (NOTE: when using the OpenAI model, the fluency scores are either 0.0
@@ -307,12 +311,13 @@ def fluency(
 
 
 def _fluency_openai(
-        generated_outputs: List[str],
-        client_type: str,
-        client: Optional[OpenAI],
-        openai_args: Optional[Dict[str, str]],
-        *,
-        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+    generated_outputs: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
+) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the fluency scores and their associated explanations of
     generated outputs using the OpenAI API, using a prompt that is similar to
     the one used in G-Eval (see the Ref below). This metric takes on float
@@ -400,14 +405,14 @@ def _fluency_openai(
     return scores, explanations
 
 
-def toxicity(
-        generated_outputs: List[str] | str,
-        prompts: Optional[List[str] | str] = None,
-        model_type: str = 'local',
-        openai_client: Optional[OpenAI] = None,
-        openai_args: Optional[Dict[str, str]] = None,
-        local_overflow_strategy: str = 'truncate'
-) -> MetricValue[Optional[float]]:
+def toxicity(generated_outputs: List[str] | str,
+             prompts: Optional[List[str] | str] = None,
+             model_type: str = 'local',
+             openai_client: Optional[OpenAI] = None,
+             openai_args: Optional[Dict[str, str]] = None,
+             local_overflow_strategy: str = 'truncate',
+             *,
+             use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the toxicity scores of generated outputs. This metric takes on
     float values between [0, 1], where 0 is low toxicity and 1 is high toxicity.
     (NOTE: when using the OpenAI model, the toxicity scores are in steps of
@@ -499,12 +504,13 @@ def _toxicity_local(generated_outputs: List[str],
 
 
 def _toxicity_openai(
-        generated_outputs: List[str],
-        client_type: str,
-        client: Optional[OpenAI],
-        openai_args: Optional[Dict[str, str]],
-        *,
-        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+    generated_outputs: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
+) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the toxicity scores and their associated explanations of
     generated outputs using the OpenAI API. This metric takes on float values
     between [0, 1] (in steps of 0.25), where 0 is low toxicity and 1 is high
@@ -702,7 +708,7 @@ def answer_relevance(generated_outputs: List[str] | str,
                      openai_client: Optional[OpenAI] = None,
                      openai_args: Optional[Dict[str, str]] = None,
                      *,
-                     use_async=False) -> MetricValue[Optional[float]]:
+                     use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of generated outputs to the prompt. This metric
     takes on float values of either 0.0 (Not Relevant), 0.5 (Partially
     Relevant), or 1.0 (Fully Relevant). The score may also be `None` if it could

--- a/src/langcheck/metrics/de/reference_free_text_quality.py
+++ b/src/langcheck/metrics/de/reference_free_text_quality.py
@@ -300,8 +300,11 @@ def fluency(generated_outputs: List[str] | str,
         scores = _metric_value.metric_values
         explanations = None
     else:  # openai or azure_openai
-        scores, explanations = _fluency_openai(generated_outputs, model_type,
-                                               openai_client, openai_args)
+        scores, explanations = _fluency_openai(generated_outputs,
+                                               model_type,
+                                               openai_client,
+                                               openai_args,
+                                               use_async=use_async)
 
     return MetricValue(metric_name='fluency',
                        prompts=prompts,
@@ -474,8 +477,11 @@ def toxicity(generated_outputs: List[str] | str,
         scores = _toxicity_local(generated_outputs, local_overflow_strategy)
         explanations = None
     else:  # openai or azure_openai
-        scores, explanations = _toxicity_openai(generated_outputs, model_type,
-                                                openai_client, openai_args)
+        scores, explanations = _toxicity_openai(generated_outputs,
+                                                model_type,
+                                                openai_client,
+                                                openai_args,
+                                                use_async=use_async)
 
     return MetricValue(metric_name='toxicity',
                        prompts=prompts,

--- a/src/langcheck/metrics/de/reference_free_text_quality.py
+++ b/src/langcheck/metrics/de/reference_free_text_quality.py
@@ -79,6 +79,7 @@ def sentiment(generated_outputs: List[str] | str,
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -165,6 +166,7 @@ def _sentiment_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API of OpenAI
 
     Returns:
         score_list: a list of scores
@@ -273,6 +275,7 @@ def fluency(generated_outputs: List[str] | str,
             attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -339,6 +342,7 @@ def _fluency_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API of OpenAI
 
     Returns:
         score_list: a list of scores
@@ -454,6 +458,7 @@ def toxicity(generated_outputs: List[str] | str,
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -529,6 +534,7 @@ def _toxicity_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API of OpenAI
 
     Returns:
         score_list: a list of scores

--- a/src/langcheck/metrics/de/reference_free_text_quality.py
+++ b/src/langcheck/metrics/de/reference_free_text_quality.py
@@ -136,9 +136,12 @@ def _sentiment_local(generated_outputs: List[str],
 
 
 def _sentiment_openai(
-    generated_outputs: List[str], client_type: str, client: Optional[OpenAI],
-    openai_args: Optional[Dict[str, str]]
-) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+        generated_outputs: List[str],
+        client_type: str,
+        client: Optional[OpenAI],
+        openai_args: Optional[Dict[str, str]],
+        *,
+        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the sentiment scores and their associated explanations of
     generated outputs using the OpenAI API. This metric takes on float values
     that are either 0, 0.5, or 1, where 0 is negative sentiment, 0.5 is neutral
@@ -214,7 +217,8 @@ def _sentiment_openai(
         argument_description='The sentiment assessment of the statement',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs), _function_call_prompt)
@@ -303,9 +307,12 @@ def fluency(
 
 
 def _fluency_openai(
-    generated_outputs: List[str], client_type: str, client: Optional[OpenAI],
-    openai_args: Optional[Dict[str, str]]
-) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+        generated_outputs: List[str],
+        client_type: str,
+        client: Optional[OpenAI],
+        openai_args: Optional[Dict[str, str]],
+        *,
+        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the fluency scores and their associated explanations of
     generated outputs using the OpenAI API, using a prompt that is similar to
     the one used in G-Eval (see the Ref below). This metric takes on float
@@ -384,7 +391,8 @@ def _fluency_openai(
         argument_description='The fluency assessment of the statement',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs), _function_call_prompt)
@@ -491,9 +499,12 @@ def _toxicity_local(generated_outputs: List[str],
 
 
 def _toxicity_openai(
-    generated_outputs: List[str], client_type: str, client: Optional[OpenAI],
-    openai_args: Optional[Dict[str, str]]
-) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+        generated_outputs: List[str],
+        client_type: str,
+        client: Optional[OpenAI],
+        openai_args: Optional[Dict[str, str]],
+        *,
+        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the toxicity scores and their associated explanations of
     generated outputs using the OpenAI API. This metric takes on float values
     between [0, 1] (in steps of 0.25), where 0 is low toxicity and 1 is high
@@ -565,7 +576,8 @@ def _toxicity_openai(
         argument_description='The toxicity assessment of the statement',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs), _function_call_prompt)
@@ -684,13 +696,13 @@ def ai_disclaimer_similarity(
                        language=LANG)
 
 
-def answer_relevance(
-    generated_outputs: List[str] | str,
-    prompts: List[str] | str,
-    model_type: str = 'openai',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def answer_relevance(generated_outputs: List[str] | str,
+                     prompts: List[str] | str,
+                     model_type: str = 'openai',
+                     openai_client: Optional[OpenAI] = None,
+                     openai_args: Optional[Dict[str, str]] = None,
+                     *,
+                     use_async=False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of generated outputs to the prompt. This metric
     takes on float values of either 0.0 (Not Relevant), 0.5 (Partially
     Relevant), or 1.0 (Fully Relevant). The score may also be `None` if it could
@@ -773,7 +785,8 @@ def answer_relevance(
         argument_description='The answer relevance assessment',
         client_type=model_type,
         client=openai_client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs, prompts), _function_call_prompt)

--- a/src/langcheck/metrics/de/source_based_text_quality.py
+++ b/src/langcheck/metrics/de/source_based_text_quality.py
@@ -121,9 +121,13 @@ def factual_consistency(
 
 
 def _factual_consistency_openai(
-    generated_outputs: List[str], sources: List[str], client_type: str,
-    client: Optional[OpenAI], openai_args: Optional[Dict[str, str]]
-) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+        generated_outputs: List[str],
+        sources: List[str],
+        client_type: str,
+        client: Optional[OpenAI],
+        openai_args: Optional[Dict[str, str]],
+        *,
+        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the factual consistency and their associated explanations
     between each generated output and its corresponding source text. The
     consistency is computed by calling the OpenAI API, with a prompt similar to
@@ -211,7 +215,8 @@ def _factual_consistency_openai(
         argument_description='The factual consistency assessment of the claim',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, sources, generated_outputs), _function_call_prompt)
@@ -219,13 +224,13 @@ def _factual_consistency_openai(
     return scores, explanations
 
 
-def context_relevance(
-    sources: List[str] | str,
-    prompts: List[str] | str,
-    model_type: str = 'openai',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def context_relevance(sources: List[str] | str,
+                      prompts: List[str] | str,
+                      model_type: str = 'openai',
+                      openai_client: Optional[OpenAI] = None,
+                      openai_args: Optional[Dict[str, str]] = None,
+                      *,
+                      use_async=False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of the sources to the prompts. This metric takes
     on float values between [0, 1], where 0 means that the source text is not at
     all relevant to the prompt, and 1 means that the source text is fully
@@ -312,7 +317,8 @@ def context_relevance(
         argument_description='The context relevance assessment',
         client_type=model_type,
         client=openai_client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, sources, prompts), _function_call_prompt)
@@ -321,7 +327,7 @@ def context_relevance(
                        prompts=prompts,
                        generated_outputs=None,
                        reference_outputs=None,
-                       sources=sources,
+                       sources=list(sources),
                        explanations=explanations,
                        metric_values=scores,
                        language=LANG)

--- a/src/langcheck/metrics/de/source_based_text_quality.py
+++ b/src/langcheck/metrics/de/source_based_text_quality.py
@@ -70,6 +70,7 @@ def factual_consistency(
             attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API for OpenAI, default False
 
     Returns:
         An MetricValue object
@@ -151,6 +152,7 @@ def _factual_consistency_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API for OpenAI
 
     Returns:
         score_list: a list of scores
@@ -262,6 +264,7 @@ def context_relevance(sources: List[str] | str,
             None, we will attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API for OpenAI, default False
     '''
     prompts, sources = validate_parameters_context_relevance(prompts, sources)
 

--- a/src/langcheck/metrics/de/source_based_text_quality.py
+++ b/src/langcheck/metrics/de/source_based_text_quality.py
@@ -83,8 +83,12 @@ def factual_consistency(
         'The supported ones are ["local", "openai", "azure_openai"]')
 
     if model_type == 'openai' or model_type == 'azure_openai':
-        scores, explanations = _factual_consistency_openai(
-            generated_outputs, sources, model_type, openai_client, openai_args)
+        scores, explanations = _factual_consistency_openai(generated_outputs,
+                                                           sources,
+                                                           model_type,
+                                                           openai_client,
+                                                           openai_args,
+                                                           use_async=use_async)
 
         return MetricValue(metric_name='factual_consistency',
                            prompts=prompts,

--- a/src/langcheck/metrics/de/source_based_text_quality.py
+++ b/src/langcheck/metrics/de/source_based_text_quality.py
@@ -19,13 +19,14 @@ LANG = 'de'
 
 
 def factual_consistency(
-    generated_outputs: List[str] | str,
-    sources: List[str] | str,
-    prompts: Optional[List[str] | str] = None,
-    model_type: str = 'local',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+        generated_outputs: List[str] | str,
+        sources: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
+        model_type: str = 'local',
+        openai_client: Optional[OpenAI] = None,
+        openai_args: Optional[Dict[str, str]] = None,
+        *,
+        use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. This metric takes on float values between [0, 1], where 0
     means that the output is not at all consistent with the source text, and 1
@@ -121,13 +122,14 @@ def factual_consistency(
 
 
 def _factual_consistency_openai(
-        generated_outputs: List[str],
-        sources: List[str],
-        client_type: str,
-        client: Optional[OpenAI],
-        openai_args: Optional[Dict[str, str]],
-        *,
-        use_async=False) -> Tuple[List[Optional[float]], List[Optional[str]]]:
+    generated_outputs: List[str],
+    sources: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
+) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the factual consistency and their associated explanations
     between each generated output and its corresponding source text. The
     consistency is computed by calling the OpenAI API, with a prompt similar to
@@ -230,7 +232,7 @@ def context_relevance(sources: List[str] | str,
                       openai_client: Optional[OpenAI] = None,
                       openai_args: Optional[Dict[str, str]] = None,
                       *,
-                      use_async=False) -> MetricValue[Optional[float]]:
+                      use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of the sources to the prompts. This metric takes
     on float values between [0, 1], where 0 means that the source text is not at
     all relevant to the prompt, and 1 means that the source text is fully

--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -69,6 +69,7 @@ def sentiment(
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
+        use_async: Whether to use the asynchronous API for OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -155,6 +156,7 @@ def _sentiment_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API for OpenAI
 
     Returns:
         score_list: a list of scores
@@ -270,6 +272,7 @@ def fluency(
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
+        use_async: Whether to use the asynchronous API for OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -356,6 +359,7 @@ def _fluency_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API for OpenAI
 
     Returns:
         score_list: a list of scores
@@ -470,7 +474,7 @@ def toxicity(
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
-
+        use_async: Whether to use the asynchronous API for OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -547,6 +551,7 @@ def _toxicity_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API for OpenAI
 
     Returns:
         score_list: a list of scores

--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -219,12 +219,14 @@ def _sentiment_openai(
 
 
 def fluency(
-        generated_outputs: List[str] | str,
-        prompts: Optional[List[str] | str] = None,
-        model_type: str = 'local',
-        openai_client: Optional[OpenAI] = None,
-        openai_args: Optional[Dict[str, str]] = None,
-        local_overflow_strategy: str = 'truncate'
+    generated_outputs: List[str] | str,
+    prompts: Optional[List[str] | str] = None,
+    model_type: str = 'local',
+    openai_client: Optional[OpenAI] = None,
+    openai_args: Optional[Dict[str, str]] = None,
+    local_overflow_strategy: str = 'truncate',
+    *,
+    use_async: bool = False,
 ) -> MetricValue[Optional[float]]:
     '''Calculates the fluency scores of generated outputs. This metric takes on
     float values between [0, 1], where 0 is low fluency and 1 is high fluency.
@@ -283,8 +285,11 @@ def fluency(
         scores = _fluency_local(generated_outputs, local_overflow_strategy)
         explanations = None
     else:  # openai or azure_openai
-        scores, explanations = _fluency_openai(generated_outputs, model_type,
-                                               openai_client, openai_args)
+        scores, explanations = _fluency_openai(generated_outputs,
+                                               model_type,
+                                               openai_client,
+                                               openai_args,
+                                               use_async=use_async)
 
     return MetricValue(metric_name='fluency',
                        prompts=prompts,
@@ -422,7 +427,7 @@ def toxicity(
     openai_args: Optional[Dict[str, str]] = None,
     local_overflow_strategy: str = 'truncate',
     *,
-    use_async=False,
+    use_async: bool = False,
 ) -> MetricValue[Optional[float]]:
     '''Calculates the toxicity scores of generated outputs. This metric takes on
     float values between [0, 1], where 0 is low toxicity and 1 is high toxicity.

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -85,8 +85,12 @@ def factual_consistency(
         scores = _factual_consistency_local(generated_outputs, sources)
         explanations = None
     else:  # openai or azure_openai
-        scores, explanations = _factual_consistency_openai(
-            generated_outputs, sources, model_type, openai_client, openai_args)
+        scores, explanations = _factual_consistency_openai(generated_outputs,
+                                                           sources,
+                                                           model_type,
+                                                           openai_client,
+                                                           openai_args,
+                                                           use_async=use_async)
 
     return MetricValue(metric_name='factual_consistency',
                        prompts=prompts,

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -207,8 +207,13 @@ def _factual_consistency_local(generated_outputs: List[str],
 
 
 def _factual_consistency_openai(
-    generated_outputs: List[str], sources: List[str], client_type: str,
-    client: Optional[OpenAI], openai_args: Optional[Dict[str, str]]
+    generated_outputs: List[str],
+    sources: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
 ) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the factual consistency and their associated explanations
     between each generated output and its corresponding source text. The
@@ -294,7 +299,8 @@ def _factual_consistency_openai(
         argument_description='The factual consistency assessment of the claim',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, sources, generated_outputs), _function_call_prompt)
@@ -302,13 +308,13 @@ def _factual_consistency_openai(
     return scores, explanations
 
 
-def context_relevance(
-    sources: List[str] | str,
-    prompts: List[str] | str,
-    model_type: str = 'openai',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def context_relevance(sources: List[str] | str,
+                      prompts: List[str] | str,
+                      model_type: str = 'openai',
+                      openai_client: Optional[OpenAI] = None,
+                      openai_args: Optional[Dict[str, str]] = None,
+                      *,
+                      use_async=False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of the sources to the prompts. This metric takes
     on float values between [0, 1], where 0 means that the source text is not at
     all relevant to the prompt, and 1 means that the source text is fully
@@ -392,7 +398,8 @@ def context_relevance(
         argument_description='The context relevance assessment',
         client_type=model_type,
         client=openai_client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, sources, prompts), _function_call_prompt)

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -23,13 +23,14 @@ _factual_consistency_model = None
 
 
 def factual_consistency(
-    generated_outputs: List[str] | str,
-    sources: List[str] | str,
-    prompts: Optional[List[str] | str] = None,
-    model_type: str = 'local',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+        generated_outputs: List[str] | str,
+        sources: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
+        model_type: str = 'local',
+        openai_client: Optional[OpenAI] = None,
+        openai_args: Optional[Dict[str, str]] = None,
+        *,
+        use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. This metric takes on float values between [0, 1], where 0
     means that the output is not at all consistent with the source text, and 1
@@ -314,7 +315,7 @@ def context_relevance(sources: List[str] | str,
                       openai_client: Optional[OpenAI] = None,
                       openai_args: Optional[Dict[str, str]] = None,
                       *,
-                      use_async=False) -> MetricValue[Optional[float]]:
+                      use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of the sources to the prompts. This metric takes
     on float values between [0, 1], where 0 means that the source text is not at
     all relevant to the prompt, and 1 means that the source text is fully

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -69,6 +69,7 @@ def factual_consistency(
             attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An MetricValue object
@@ -237,6 +238,7 @@ def _factual_consistency_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API of OpenAI
 
     Returns:
         score_list: a list of scores
@@ -345,6 +347,7 @@ def context_relevance(sources: List[str] | str,
             None, we will attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
     '''
     prompts, sources = validate_parameters_context_relevance(prompts, sources)
 

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -14,14 +14,14 @@ from langcheck.metrics.scorer.hf_models import \
 from langcheck.utils.progess_bar import tqdm_wrapper
 
 
-def sentiment(
-        generated_outputs: List[str] | str,
-        prompts: Optional[List[str] | str] = None,
-        model_type: str = 'local',
-        openai_client: Optional[OpenAI] = None,
-        openai_args: Optional[Dict[str, str]] = None,
-        local_overflow_strategy: str = 'truncate'
-) -> MetricValue[Optional[float]]:
+def sentiment(generated_outputs: List[str] | str,
+              prompts: Optional[List[str] | str] = None,
+              model_type: str = 'local',
+              openai_client: Optional[OpenAI] = None,
+              openai_args: Optional[Dict[str, str]] = None,
+              local_overflow_strategy: str = 'truncate',
+              *,
+              use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the sentiment scores of generated outputs. This metric takes
     on float values between [0, 1], where 0 is negative sentiment and 1 is
     positive sentiment. (NOTE: when using the OpenAI model, the sentiment scores
@@ -82,8 +82,11 @@ def sentiment(
         scores = _sentiment_local(generated_outputs, local_overflow_strategy)
         explanations = None
     else:  # openai or azure_openai
-        scores, explanations = _sentiment_openai(generated_outputs, model_type,
-                                                 openai_client, openai_args)
+        scores, explanations = _sentiment_openai(generated_outputs,
+                                                 model_type,
+                                                 openai_client,
+                                                 openai_args,
+                                                 use_async=use_async)
 
     return MetricValue(metric_name='sentiment',
                        prompts=prompts,
@@ -125,8 +128,12 @@ def _sentiment_local(generated_outputs: List[str],
 
 
 def _sentiment_openai(
-    generated_outputs: List[str], client_type: str, client: Optional[OpenAI],
-    openai_args: Optional[Dict[str, str]]
+    generated_outputs: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
 ) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the sentiment scores and their associated explanations of
     generated outputs using the OpenAI API. This metric takes on float values
@@ -196,7 +203,8 @@ def _sentiment_openai(
         argument_description='The sentiment assessment of the statement',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs), _function_call_prompt)
@@ -205,12 +213,14 @@ def _sentiment_openai(
 
 
 def toxicity(
-        generated_outputs: List[str] | str,
-        prompts: Optional[List[str] | str] = None,
-        model_type: str = 'local',
-        openai_client: Optional[OpenAI] = None,
-        openai_args: Optional[Dict[str, str]] = None,
-        local_overflow_strategy: str = 'truncate'
+    generated_outputs: List[str] | str,
+    prompts: Optional[List[str] | str] = None,
+    model_type: str = 'local',
+    openai_client: Optional[OpenAI] = None,
+    openai_args: Optional[Dict[str, str]] = None,
+    local_overflow_strategy: str = 'truncate',
+    *,
+    use_async: bool = False,
 ) -> MetricValue[Optional[float]]:
     '''Calculates the toxicity scores of generated outputs. This metric takes on
     float values between [0, 1], where 0 is low toxicity and 1 is high toxicity.
@@ -275,8 +285,11 @@ def toxicity(
         scores = _toxicity_local(generated_outputs, local_overflow_strategy)
         explanations = None
     else:  # openai or azure_openai
-        scores, explanations = _toxicity_openai(generated_outputs, model_type,
-                                                openai_client, openai_args)
+        scores, explanations = _toxicity_openai(generated_outputs,
+                                                model_type,
+                                                openai_client,
+                                                openai_args,
+                                                use_async=use_async)
 
     return MetricValue(metric_name='toxicity',
                        prompts=prompts,
@@ -317,8 +330,12 @@ def _toxicity_local(generated_outputs: List[str],
 
 
 def _toxicity_openai(
-    generated_outputs: List[str], client_type: str, client: Optional[OpenAI],
-    openai_args: Optional[Dict[str, str]]
+    generated_outputs: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
 ) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the toxicity scores and their associated explanations of
     generated outputs using the OpenAI API. This metric takes on float values
@@ -388,7 +405,8 @@ def _toxicity_openai(
         argument_description='The toxicity assessment of the statement',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs), _function_call_prompt)
@@ -396,14 +414,14 @@ def _toxicity_openai(
     return scores, explanations
 
 
-def fluency(
-        generated_outputs: List[str] | str,
-        prompts: Optional[List[str] | str] = None,
-        model_type: str = 'local',
-        openai_client: Optional[OpenAI] = None,
-        openai_args: Optional[Dict[str, str]] = None,
-        local_overflow_strategy: str = 'truncate'
-) -> MetricValue[Optional[float]]:
+def fluency(generated_outputs: List[str] | str,
+            prompts: Optional[List[str] | str] = None,
+            model_type: str = 'local',
+            openai_client: Optional[OpenAI] = None,
+            openai_args: Optional[Dict[str, str]] = None,
+            local_overflow_strategy: str = 'truncate',
+            *,
+            use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the fluency scores of generated outputs. This metric takes on
     float values between [0, 1], where 0 is low fluency and 1 is high fluency.
     (NOTE: when using the OpenAI model, the fluency scores are either 0.0
@@ -467,8 +485,11 @@ def fluency(
         scores = _fluency_local(generated_outputs, local_overflow_strategy)
         explanations = None
     else:  # openai or azure_openai
-        scores, explanations = _fluency_openai(generated_outputs, model_type,
-                                               openai_client, openai_args)
+        scores, explanations = _fluency_openai(generated_outputs,
+                                               model_type,
+                                               openai_client,
+                                               openai_args,
+                                               use_async=use_async)
 
     return MetricValue(metric_name='fluency',
                        prompts=prompts,
@@ -509,8 +530,12 @@ def _fluency_local(generated_outputs: List[str],
 
 
 def _fluency_openai(
-    generated_outputs: List[str], client_type: str, client: Optional[OpenAI],
-    openai_args: Optional[Dict[str, str]]
+    generated_outputs: List[str],
+    client_type: str,
+    client: Optional[OpenAI],
+    openai_args: Optional[Dict[str, str]],
+    *,
+    use_async: bool = False
 ) -> Tuple[List[Optional[float]], List[Optional[str]]]:
     '''Calculates the fluency scores and their associated explanations of
     generated outputs using the OpenAI API, using a prompt that is similar to
@@ -582,7 +607,8 @@ def _fluency_openai(
         argument_description='The fluency assessment of the statement',
         client_type=client_type,
         client=client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs), _function_call_prompt)

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -674,13 +674,13 @@ def tateishi_ono_yamada_reading_ease(
                        language='ja')
 
 
-def answer_relevance(
-    generated_outputs: List[str] | str,
-    prompts: List[str] | str,
-    model_type: str = 'openai',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def answer_relevance(generated_outputs: List[str] | str,
+                     prompts: List[str] | str,
+                     model_type: str = 'openai',
+                     openai_client: Optional[OpenAI] = None,
+                     openai_args: Optional[Dict[str, str]] = None,
+                     *,
+                     use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of generated outputs to the prompt. This metric
     takes on float values of either 0.0 (Not Relevant), 0.5 (Partially
     Relevant), or 1.0 (Fully Relevant). The score may also be `None` if it could
@@ -755,7 +755,8 @@ def answer_relevance(
         argument_description='The answer relevance assessment',
         client_type=model_type,
         client=openai_client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, generated_outputs, prompts), _function_call_prompt)

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -67,6 +67,7 @@ def sentiment(generated_outputs: List[str] | str,
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
+        use_async: Whether to use the asynchronous API of OpenAI. Default is
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -154,6 +155,7 @@ def _sentiment_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API of OpenAI
 
     Returns:
         score_list: a list of scores
@@ -270,6 +272,7 @@ def toxicity(
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
+        use_async: Whether to use the asynchronous API of OpenAI. Default is
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -355,6 +358,7 @@ def _toxicity_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API of OpenAI
 
     Returns:
         score_list: a list of scores
@@ -470,6 +474,7 @@ def fluency(generated_outputs: List[str] | str,
             will be assigned a score of None. If 'truncate', the outputs that
             are too long will be truncated. If 'raise', an error will be raised
             when the outputs are too long. The default value is 'nullify'.
+        use_async: Whether to use the asynchronous API of OpenAI. Default is
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -558,6 +563,7 @@ def _fluency_openai(
             ``client_type``.
         openai_args: (Optional) Dict of additional args to pass in to the
             ``client.chat.completions.create`` function
+        use_async: Whether to use the asynchronous API of OpenAI
 
     Returns:
         score_list: a list of scores

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -175,6 +175,7 @@ def context_relevance(sources: List[str] | str,
             None, we will attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API, default False
     '''
     prompts, sources = validate_parameters_context_relevance(prompts, sources)
 

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -139,13 +139,13 @@ def factual_consistency(
                        language='ja')
 
 
-def context_relevance(
-    sources: List[str] | str,
-    prompts: List[str] | str,
-    model_type: str = 'openai',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def context_relevance(sources: List[str] | str,
+                      prompts: List[str] | str,
+                      model_type: str = 'openai',
+                      openai_client: Optional[OpenAI] = None,
+                      openai_args: Optional[Dict[str, str]] = None,
+                      *,
+                      use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the relevance of the sources to the prompts. This metric takes
     on float values between [0, 1], where 0 means that the source text is not at
     all relevant to the prompt, and 1 means that the source text is fully
@@ -226,7 +226,8 @@ def context_relevance(
         argument_description='The context relevance assessment',
         client_type=model_type,
         client=openai_client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     scores, explanations = oai_evaluator.get_score(
         map(_prompt, sources, prompts), _function_call_prompt)

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -19,13 +19,14 @@ _factual_consistency_translation_pipeline: Pipeline | None = None
 
 
 def factual_consistency(
-    generated_outputs: List[str] | str,
-    sources: List[str] | str,
-    prompts: Optional[List[str] | str] = None,
-    model_type: str = 'local',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+        generated_outputs: List[str] | str,
+        sources: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
+        model_type: str = 'local',
+        openai_client: Optional[OpenAI] = None,
+        openai_args: Optional[Dict[str, str]] = None,
+        *,
+        use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. This metric takes on float values between [0, 1], where 0
     means that the output is not at all consistent with the source text, and 1
@@ -69,6 +70,7 @@ def factual_consistency(
             attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An MetricValue object
@@ -83,9 +85,13 @@ def factual_consistency(
     # The English prompt works well enough for Japanese
     # TODO: Investigate the performance improvement with Japanese prompt
     if model_type == 'openai' or model_type == 'azure_openai':
-        metric_value = en_factual_consistency(generated_outputs, sources,
-                                              prompts, model_type,
-                                              openai_client, openai_args)
+        metric_value = en_factual_consistency(generated_outputs,
+                                              sources,
+                                              prompts,
+                                              model_type,
+                                              openai_client,
+                                              openai_args,
+                                              use_async=use_async)
         metric_value.language = 'ja'
         return metric_value
 

--- a/src/langcheck/metrics/zh/reference_free_text_quality.py
+++ b/src/langcheck/metrics/zh/reference_free_text_quality.py
@@ -13,13 +13,13 @@ from langcheck.metrics.en.reference_free_text_quality import \
 from langcheck.metrics.metric_value import MetricValue
 
 
-def sentiment(
-    generated_outputs: List[str] | str,
-    prompts: Optional[List[str] | str] = None,
-    model_type: str = 'local',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def sentiment(generated_outputs: List[str] | str,
+              prompts: Optional[List[str] | str] = None,
+              model_type: str = 'local',
+              openai_client: Optional[OpenAI] = None,
+              openai_args: Optional[Dict[str, str]] = None,
+              *,
+              use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the sentiment scores of generated outputs. This metric takes
     on float values between [0, 1], where 0 is negative sentiment and 1 is
     positive sentiment. (NOTE: when using the OpenAI model, the sentiment scores
@@ -59,6 +59,7 @@ def sentiment(
             attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -71,8 +72,12 @@ def sentiment(
         'The supported ones are ["local", "openai", "azure_openai"]')
 
     if model_type == 'openai' or model_type == 'azure_openai':
-        metric_value = en_sentiment(generated_outputs, prompts, model_type,
-                                    openai_client, openai_args)
+        metric_value = en_sentiment(generated_outputs,
+                                    prompts,
+                                    model_type,
+                                    openai_client,
+                                    openai_args,
+                                    use_async=use_async)
         metric_value.language = 'zh'
         return metric_value
 
@@ -107,13 +112,13 @@ def sentiment(
         language='zh')
 
 
-def toxicity(
-    generated_outputs: List[str] | str,
-    prompts: Optional[List[str] | str] = None,
-    model_type: str = 'local',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+def toxicity(generated_outputs: List[str] | str,
+             prompts: Optional[List[str] | str] = None,
+             model_type: str = 'local',
+             openai_client: Optional[OpenAI] = None,
+             openai_args: Optional[Dict[str, str]] = None,
+             *,
+             use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the toxicity scores of generated outputs. This metric takes on
     float values between [0, 1], where 0 is low toxicity and 1 is high toxicity.
     (NOTE: when using the OpenAI model, the toxicity scores are in steps of
@@ -154,6 +159,7 @@ def toxicity(
             attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An :class:`~langcheck.metrics.metric_value.MetricValue` object
@@ -167,8 +173,11 @@ def toxicity(
 
     if model_type == 'openai' or model_type == 'azure_openai':
         # openai
-        scores, explanations = _toxicity_openai(generated_outputs, model_type,
-                                                openai_client, openai_args)
+        scores, explanations = _toxicity_openai(generated_outputs,
+                                                model_type,
+                                                openai_client,
+                                                openai_args,
+                                                use_async=use_async)
     else:
         scores = _toxicity_local(generated_outputs)
         explanations = None

--- a/src/langcheck/metrics/zh/source_based_text_quality.py
+++ b/src/langcheck/metrics/zh/source_based_text_quality.py
@@ -12,13 +12,14 @@ from langcheck.metrics.metric_value import MetricValue
 
 
 def factual_consistency(
-    generated_outputs: List[str] | str,
-    sources: List[str] | str,
-    prompts: Optional[List[str] | str] = None,
-    model_type: str = 'local',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+        generated_outputs: List[str] | str,
+        sources: List[str] | str,
+        prompts: Optional[List[str] | str] = None,
+        model_type: str = 'local',
+        openai_client: Optional[OpenAI] = None,
+        openai_args: Optional[Dict[str, str]] = None,
+        *,
+        use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the factual consistency between the generated outputs and
     the sources. This metric takes on float values between [0, 1], where 0
     means that the output is not at all consistent with the source text, and 1
@@ -62,6 +63,7 @@ def factual_consistency(
             attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An MetricValue object
@@ -74,9 +76,13 @@ def factual_consistency(
         'The supported ones are ["local", "openai", "azure_openai"]')
 
     if model_type == 'openai' or model_type == 'azure_openai':
-        metric_value = en_factual_consistency(generated_outputs, sources,
-                                              prompts, model_type,
-                                              openai_client, openai_args)
+        metric_value = en_factual_consistency(generated_outputs,
+                                              sources,
+                                              prompts,
+                                              model_type,
+                                              openai_client,
+                                              openai_args,
+                                              use_async=use_async)
         metric_value.language = 'zh'
         return metric_value
 


### PR DESCRIPTION
## Motivation

The bottleneck of the OpenAI-based evaluator is IO time. This PR introduces an asynchronous API call option for each metric evaluation.