### PR TITLE
Update pytest status badge and run tests on PR merge

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,12 @@ on:
   # Triggers the workflow on pull request events
   pull_request:
 
+  # Triggers the workflow when a pull request merges into the main branch (this
+  # causes a `push` event). This is used for the test status badge in README.md
+  push:
+    branches:
+      - main
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src="docs/_static/LangCheck-Logo-White-square.png#gh-dark-mode-only" alt="LangCheck Logo" width="275">
 
 [![](https://dcbadge.vercel.app/api/server/Bkndx9RXqw?compact=true&style=flat)](https://discord.gg/Bkndx9RXqw)
-[![Pytest Tests](https://github.com/citadel-ai/langcheck/actions/workflows/pytest.yml/badge.svg)](https://github.com/citadel-ai/langcheck/actions/workflows/pytest.yml)
+[![Pytest Tests](https://github.com/citadel-ai/langcheck/actions/workflows/pytest.yml/badge.svg?event=push&branch=main)](https://github.com/citadel-ai/langcheck/actions/workflows/pytest.yml)
 [![Downloads](https://static.pepy.tech/badge/langcheck)](https://pepy.tech/project/langcheck)
 ![GitHub](https://img.shields.io/github/license/citadel-ai/langcheck)
 


### PR DESCRIPTION
Based on IRL conversation. We now run pytest when a PR merges into main, and the status badge is updated to only read these events.

It's a bit wasteful but I didn't find an alternative way to do this. 

Relevant documentation: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-event-parameter