### PR TITLE
Japanese pairwise comparison metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ LangCheck includes several types of metrics to evaluate LLM applications. Some e
 | [Reference-Based Text Quality Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#reference-based-text-quality-metrics) | `semantic_similarity(generated_outputs, reference_outputs)`<br>`rouge2(generated_outputs, reference_outputs)`    | EN, JA, ZH, DE        |
 | [Source-Based Text Quality Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#source-based-text-quality-metrics)       | `factual_consistency(generated_outputs, sources)`                                                                | EN, JA, ZH, DE        |
 | [Text Structure Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#text-structure-metrics)                             | `is_float(generated_outputs, min=0, max=None)`<br>`is_json_object(generated_outputs)`                            | All Languages |
-| [Pairwise Text Quality Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#pairwise-text-quality-metrics) | `pairwise_comparison(generated_outputs_a, generated_outputs_b, prompts)` | EN |
+| [Pairwise Text Quality Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#pairwise-text-quality-metrics) | `pairwise_comparison(generated_outputs_a, generated_outputs_b, prompts)` | EN, JA |
 
 ### Visualize Metrics
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -65,6 +65,7 @@ LangCheckには、他にも以下のようなLLMアプリケーションを評�
 | [Reference-Based Text Quality Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#reference-based-text-quality-metrics) | `semantic_similarity(generated_outputs, reference_outputs)`<br>`rouge2(generated_outputs, reference_outputs)` | 英語、日本語、中国語、ドイツ語 |
 | [Source-Based Text Quality Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#source-based-text-quality-metrics)       | `factual_consistency(generated_outputs, sources)`                                                             | 英語、日本語、中国語、ドイツ語 |
 | [Text Structure Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#text-structure-metrics)                             | `is_float(generated_outputs, min=0, max=None)`<br>`is_json_object(generated_outputs)`                         | 全ての言語   |
+| [Pairwise Text Quality Metrics](https://langcheck.readthedocs.io/en/latest/metrics.html#pairwise-text-quality-metrics) | `pairwise_comparison(generated_outputs_a, generated_outputs_b, prompts)` | 英語、日本語 |
 
 ### 数値の可視化
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,7 +47,7 @@ LangCheck metrics are categorized by metric type, which correspond to the kind o
 | [Reference-Based Text Quality Metrics](#reference-based-text-quality-metrics) | `semantic_similarity(generated_outputs, reference_outputs)`<br>`rouge2(generated_outputs, reference_outputs)`    | EN, JA, DE        |
 | [Source-Based Text Quality Metrics](#source-based-text-quality-metrics)       | `factual_consistency(generated_outputs, sources)`                                                                | EN, JA, DE        |
 | [Text Structure Metrics](#text-structure-metrics)                             | `is_float(generated_outputs, min=0, max=None)`<br>`is_json_object(generated_outputs)`                            | All Languages |
-| [Pairwise Text Quality Metrics](#pairwise-text-quality-metrics) | `pairwise_comparison(generated_outputs_a, generated_outputs_b, prompts)` | EN |
+| [Pairwise Text Quality Metrics](#pairwise-text-quality-metrics) | `pairwise_comparison(generated_outputs_a, generated_outputs_b, prompts)` | EN, JA |
 
 (reference-free-text-quality-metrics)=
 ### Reference-Free Text Quality Metrics

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 
 

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -1,0 +1,59 @@
+from typing import Callable, Optional
+
+
+class PairwiseComparisonPromptGenerator:
+
+    def __init__(self, base_prompt_template: Callable,
+                 prompt_template_with_reference: Callable,
+                 prompt_template_with_source: Callable,
+                 prompt_template_with_source_and_reference: Callable) -> None:
+        self.base_prompt_template = base_prompt_template
+        self.prompt_template_with_reference = prompt_template_with_reference
+        self.prompt_template_with_source = prompt_template_with_source
+        self.prompt_template_with_source_and_reference = prompt_template_with_source_and_reference  # NOQA: E501
+
+    def generate_prompts(self, generated_outputs_1: list[str],
+                         generated_outputs_2: list[str], prompts: list[str],
+                         sources_1: Optional[list[str]],
+                         sources_2: Optional[list[str]],
+                         reference_outputs: Optional[list[str]]) -> list[str]:
+        '''Generate prompts for the pairwise comparison metric.
+
+        Args:
+            generated_outputs_1: Model 1's generated output(s) to evaluate
+            generated_outputs_2: Model 2's generated output(s) to evaluate
+            prompts: The prompts used to generate the output(s).
+            sources_1: (Optional) the source(s) of Model 1's generated output(s)
+            sources_2: (Optional) the source(s) of Model 2's generated output(s)
+            reference_outputs: (Optional) the reference output(s)
+
+        Returns:
+            A list of prompts
+        '''
+        # Combine sources_1 and sources_2 into a single list if both are
+        # provided.
+        if sources_1 is not None and sources_2 is not None:
+            sources = [
+                source_1 + '\n' + source_2
+                for source_1, source_2 in zip(sources_1, sources_2)
+            ]
+        else:
+            sources = sources_1 if sources_1 is not None else sources_2
+
+        if sources is not None and reference_outputs is not None:
+            prompt_fn = self.prompt_template_with_source_and_reference
+            data_iter = zip(generated_outputs_1, generated_outputs_2, prompts,
+                            reference_outputs, sources)
+        elif sources is not None:
+            prompt_fn = self.prompt_template_with_source
+            data_iter = zip(generated_outputs_1, generated_outputs_2, prompts,
+                            sources)
+        elif reference_outputs is not None:
+            prompt_fn = self.prompt_template_with_reference
+            data_iter = zip(generated_outputs_1, generated_outputs_2, prompts,
+                            reference_outputs)
+        else:
+            prompt_fn = self.base_prompt_template
+            data_iter = zip(generated_outputs_1, generated_outputs_2, prompts)
+
+        return [prompt_fn(*data_instance) for data_instance in data_iter]

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -6,12 +6,11 @@ from typing import Callable
 class PairwiseComparisonPromptGenerator:
 
     def __init__(
-        self, base_prompt_template: Callable[[str, str, str]],
-        prompt_template_with_reference: Callable[[str, str, str, str]],
-        prompt_template_with_source: Callable[[str, str, str, str]],
-        prompt_template_with_source_and_reference: Callable[[
-            str, str, str, str, str
-        ]]
+        self, base_prompt_template: Callable[[str, str, str], str],
+        prompt_template_with_reference: Callable[[str, str, str, str], str],
+        prompt_template_with_source: Callable[[str, str, str, str], str],
+        prompt_template_with_source_and_reference: Callable[
+            [str, str, str, str, str], str]
     ) -> None:
         '''Initialize the PairwiseComparisonPromptGenerator.
 

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable
 
 
 class PairwiseComparisonPromptGenerator:
@@ -14,9 +14,9 @@ class PairwiseComparisonPromptGenerator:
 
     def generate_prompts(self, generated_outputs_1: list[str],
                          generated_outputs_2: list[str], prompts: list[str],
-                         sources_1: Optional[list[str]],
-                         sources_2: Optional[list[str]],
-                         reference_outputs: Optional[list[str]]) -> list[str]:
+                         sources_1: list[str] | None,
+                         sources_2: list[str] | None,
+                         reference_outputs: list[str] | None) -> list[str]:
         '''Generate prompts for the pairwise comparison metric.
 
         Args:
@@ -57,3 +57,37 @@ class PairwiseComparisonPromptGenerator:
             data_iter = zip(generated_outputs_1, generated_outputs_2, prompts)
 
         return [prompt_fn(*data_instance) for data_instance in data_iter]
+
+
+def enforce_pairwise_comparison_consistency(
+    original_scores: list[float | None],
+    original_explanations: list[str | None], swapped_scores: list[float | None],
+    swapped_explanations: list[str | None]
+) -> tuple[list[float | None], list[str | None]]:
+    '''Enforce consistency in pairwise comparison scores.
+
+    Args:
+        original_scores: The scores for the original order of the models
+        original_explanations: The explanations for the original order of the
+            models
+        swapped_scores: The scores for the swapped order of the models
+        swapped_explanations: The explanations for the swapped order of the
+            models
+    '''
+    # Iterate through the scores and explanations to check for consistency.
+    # If a score is not consistent, set it to None, and merge the two
+    # explanations to show the inconsistency.
+    scores = original_scores.copy()
+    explanations = original_explanations.copy()
+    for i in range(len(scores)):
+        if scores[i] is None or swapped_scores[i] is None:
+            # If either score is None, we cannot determine consistency, so
+            # we set the score and explanation to None
+            scores[i] = None
+            explanations[i] = None
+            continue
+        if scores[i] + swapped_scores[i] != 1.0:  # type: ignore
+            scores[i] = None
+            explanations[
+                i] = f'Original assessment: {explanations[i]}\nSwapped assessment: {swapped_explanations[i]}'  # NOQA: E501
+    return scores, explanations

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -5,10 +5,35 @@ from typing import Callable
 
 class PairwiseComparisonPromptGenerator:
 
-    def __init__(self, base_prompt_template: Callable,
-                 prompt_template_with_reference: Callable,
-                 prompt_template_with_source: Callable,
-                 prompt_template_with_source_and_reference: Callable) -> None:
+    def __init__(
+        self, base_prompt_template: Callable[[str, str, str]],
+        prompt_template_with_reference: Callable[[str, str, str, str]],
+        prompt_template_with_source: Callable[[str, str, str, str]],
+        prompt_template_with_source_and_reference: Callable[[
+            str, str, str, str, str
+        ]]
+    ) -> None:
+        '''Initialize the PairwiseComparisonPromptGenerator.
+
+        Args:
+            base_prompt_template: The base prompt template to use when no
+                sources or reference outputs are provided. The function's inputs
+                should be the generated output from Model A, the generated
+                output from Model B, and the input prompt.
+            prompt_template_with_reference: The prompt template to use when
+                reference outputs are provided. The function's inputs should be
+                the generated output from Model A, the generated output from
+                Model B, the input prompt, and the reference output.
+            prompt_template_with_source: The prompt template to use when
+                sources are provided. The function's inputs should be the
+                generated output from Model A, the generated output from Model
+                B, the input prompt, and the source.
+            prompt_template_with_source_and_reference: The prompt template to
+                use when sources and reference outputs are provided. The
+                function's inputs should be the generated output from Model A,
+                the generated output from Model B, the input prompt, the
+                reference output, and the source.
+        '''
         self.base_prompt_template = base_prompt_template
         self.prompt_template_with_reference = prompt_template_with_reference
         self.prompt_template_with_source = prompt_template_with_source

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -13,17 +13,18 @@ from langcheck.metrics.metric_value import MetricValue
 
 
 def pairwise_comparison(
-    generated_outputs_a: List[str] | str,
-    generated_outputs_b: List[str] | str,
-    prompts: List[str] | str,
-    sources_a: Optional[List[str] | str] = None,
-    sources_b: Optional[List[str] | str] = None,
-    reference_outputs: Optional[List[str] | str] = None,
-    enforce_consistency: bool = True,
-    model_type: str = 'openai',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+        generated_outputs_a: List[str] | str,
+        generated_outputs_b: List[str] | str,
+        prompts: List[str] | str,
+        sources_a: Optional[List[str] | str] = None,
+        sources_b: Optional[List[str] | str] = None,
+        reference_outputs: Optional[List[str] | str] = None,
+        enforce_consistency: bool = True,
+        model_type: str = 'openai',
+        openai_client: Optional[OpenAI] = None,
+        openai_args: Optional[Dict[str, str]] = None,
+        *,
+        use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the pairwise comparison metric. This metric takes on float
     values of either 0.0 (Response A is better), 0.5 (Tie), or 1.0 (Response B
     is better). The score may also be `None` if it could not be computed.
@@ -66,6 +67,7 @@ def pairwise_comparison(
             None, we will attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An MetricValue object
@@ -230,7 +232,8 @@ def pairwise_comparison(
         argument_description='The pairwise comparison assessment',
         client_type=model_type,
         client=openai_client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     prompt_generator = PairwiseComparisonPromptGenerator(
         _prompt, _prompt_with_reference, _prompt_with_source,

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -251,8 +251,13 @@ def pairwise_comparison(
         all_swapped_prompts = prompt_generator.generate_prompts(
             generated_outputs_b, generated_outputs_a, prompts, sources_b,
             sources_a, reference_outputs)
+        intermediate_tqdm = '[Swapped model outputs order] Intermediate assessments (1/2)'  # NOQA: E501
+        score_tqdm = '[Swapped model outputs order] Calculating scores (2/2)'
         swapped_scores, swapped_explanations = oai_evaluator.get_score(
-            all_swapped_prompts, _function_call_prompt)
+            all_swapped_prompts,
+            _function_call_prompt,
+            intermediate_tqdm_description=intermediate_tqdm,
+            score_tqdm_description=score_tqdm)
         scores, explanations = enforce_pairwise_comparison_consistency(
             scores, explanations, swapped_scores, swapped_explanations)
 

--- a/src/langcheck/metrics/ja/__init__.py
+++ b/src/langcheck/metrics/ja/__init__.py
@@ -1,4 +1,5 @@
 from langcheck.metrics.ja._tokenizers import JanomeTokenizer, MeCabTokenizer
+from langcheck.metrics.ja.pairwise_text_quality import pairwise_comparison
 from langcheck.metrics.ja.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
 from langcheck.metrics.ja.reference_free_text_quality import (
@@ -9,7 +10,7 @@ from langcheck.metrics.ja.source_based_text_quality import (context_relevance,
 
 __all__ = [
     'answer_relevance', 'context_relevance', 'factual_consistency',
-    'JanomeTokenizer', 'MeCabTokenizer', 'rouge1', 'rouge2', 'rougeL',
-    'semantic_similarity', 'fluency', 'sentiment',
+    'JanomeTokenizer', 'MeCabTokenizer', 'pairwise_comparison', 'rouge1',
+    'rouge2', 'rougeL', 'semantic_similarity', 'fluency', 'sentiment',
     'tateishi_ono_yamada_reading_ease', 'toxicity'
 ]

--- a/src/langcheck/metrics/ja/pairwise_text_quality.py
+++ b/src/langcheck/metrics/ja/pairwise_text_quality.py
@@ -44,10 +44,6 @@ def pairwise_comparison(
     model deployment to use in ``openai_args``, e.g.
     ``openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}``
 
-    Ref:
-        Our prompt is similar to the prompt used in
-        https://arxiv.org/abs/2306.05685
-
     Args:
         generated_outputs_a: Model A's generated output(s) to evaluate
         generated_outputs_b: Model B's generated output(s) to evaluate

--- a/src/langcheck/metrics/ja/pairwise_text_quality.py
+++ b/src/langcheck/metrics/ja/pairwise_text_quality.py
@@ -13,17 +13,18 @@ from langcheck.metrics.metric_value import MetricValue
 
 
 def pairwise_comparison(
-    generated_outputs_a: List[str] | str,
-    generated_outputs_b: List[str] | str,
-    prompts: List[str] | str,
-    sources_a: Optional[List[str] | str] = None,
-    sources_b: Optional[List[str] | str] = None,
-    reference_outputs: Optional[List[str] | str] = None,
-    enforce_consistency: bool = True,
-    model_type: str = 'openai',
-    openai_client: Optional[OpenAI] = None,
-    openai_args: Optional[Dict[str,
-                               str]] = None) -> MetricValue[Optional[float]]:
+        generated_outputs_a: List[str] | str,
+        generated_outputs_b: List[str] | str,
+        prompts: List[str] | str,
+        sources_a: Optional[List[str] | str] = None,
+        sources_b: Optional[List[str] | str] = None,
+        reference_outputs: Optional[List[str] | str] = None,
+        enforce_consistency: bool = True,
+        model_type: str = 'openai',
+        openai_client: Optional[OpenAI] = None,
+        openai_args: Optional[Dict[str, str]] = None,
+        *,
+        use_async: bool = False) -> MetricValue[Optional[float]]:
     '''Calculates the pairwise comparison metric. This metric takes on float
     values of either 0.0 (Response A is better), 0.5 (Tie), or 1.0 (Response B
     is better). The score may also be `None` if it could not be computed.
@@ -66,6 +67,7 @@ def pairwise_comparison(
             None, we will attempt to create a default client.
         openai_args: Dict of additional args to pass in to the
             ``client.chat.completions.create`` function, default None
+        use_async: Whether to use the asynchronous API of OpenAI, default False
 
     Returns:
         An MetricValue object
@@ -219,7 +221,8 @@ def pairwise_comparison(
         argument_description='The pairwise comparison assessment',
         client_type=model_type,
         client=openai_client,
-        openai_args=openai_args)
+        openai_args=openai_args,
+        use_async=use_async)
 
     prompt_generator = PairwiseComparisonPromptGenerator(
         _prompt, _prompt_with_reference, _prompt_with_source,

--- a/src/langcheck/metrics/ja/pairwise_text_quality.py
+++ b/src/langcheck/metrics/ja/pairwise_text_quality.py
@@ -80,11 +80,10 @@ def pairwise_comparison(
 
     def _prompt(gen_output_a: str, gen_output_b: str, user_query: str) -> str:
         return f'''
-        You are comparing the quality of two responses to a user's query. Here
-        is the data:
+        ユーザーの質問に対する2つの回答の品質を比較してください。データは以下の通りです:
         [BEGIN DATA]
         ************
-        [User Query]: {user_query}
+        [ユーザーの質問]: {user_query}
         ************
         [Response A]: {gen_output_a}
         ************
@@ -92,29 +91,27 @@ def pairwise_comparison(
         ************
         [END DATA]
 
-        Determine which of the responses is a better response to the user's
-        query. Consider factors such as helpfulness, correctness, and relevance
-        in your assessment. Do not allow the order in which the responses were
-        presented to influence your assessment. Do not allow the length of the
-        responses to influence your assessment. The available assessments are:
-        `Response A` - Response A is a better response.
-        `Response B` - Response B is a better response.
-        `Tie` - The two responses are roughly equal in quality.
+        ユーザーの質問に対してどちらの回答がより良いかを決定してください。有用性、正確さ、
+        関連性などの要素を考慮して評価してください。回答が提示された順序に評価が影響されない
+        ようにしてください。回答の長さが評価に影響を与えないようにしてください。利用可能な評価
+        は以下の通りです:
+        `Response A` - Response Aがより良い回答です。
+        `Response B` - Response Bがより良い回答です。
+        `Tie` - 2つの回答は品質がほぼ同等です。
 
-        Take a deep breath and work on this problem step-by-step.
+        深呼吸をして、この問題をステップバイステップで取り組んでください。
         '''
 
     def _prompt_with_reference(gen_output_a: str, gen_output_b: str,
                                user_query: str, ref_output: str) -> str:
         return f'''
-        You are comparing the quality of two responses to a user's query. The
-        ideal response to the user's query is also provided to you as a
-        reference. Here is the data:
+        ユーザーの質問に対する2つの回答の品質を比較してください。ユーザーの質問に対する理想的な
+        回答も参考として提供されます。データは以下の通りです:
         [BEGIN DATA]
         ************
-        [User Query]: {user_query}
+        [ユーザーの質問]: {user_query}
         ************
-        [Ideal Response]: {ref_output}
+        [理想的な回答]: {ref_output}
         ************
         [Response A]: {gen_output_a}
         ************
@@ -122,31 +119,28 @@ def pairwise_comparison(
         ************
         [END DATA]
 
-        Determine which of the responses is a better response to the user's
-        query. Consider factors such as helpfulness, correctness, and relevance
-        in your assessment, using the provided Ideal Response as a reference. Do
-        not allow the order in which the responses were presented to influence
-        your assessment. Do not allow the length of the responses to influence
-        your assessment. The available assessments are:
-        `Response A` - Response A is a better response.
-        `Response B` - Response B is a better response.
-        `Tie` - The two responses are roughly equal in quality.
+        ユーザーの質問に対してどちらの回答がより良いかを決定してください。提供された理想的な
+        回答を参考にして、有用性、正確さ、関連性などの要素を考慮して評価してください。回答が
+        提示された順序に評価が影響されないようにしてください。回答の長さが評価に影響を与えない
+        ようにしてください。利用可能な評価は以下の通りです:
+        `Response A` - Response Aがより良い回答です。
+        `Response B` - Response Bがより良い回答です。
+        `Tie` - 2つの回答は品質がほぼ同等です。
 
-        Take a deep breath and work on this problem step-by-step.
+        深呼吸をして、この問題をステップバイステップで取り組んでください。
         '''
 
     def _prompt_with_source(gen_output_a: str, gen_output_b: str,
                             user_query: str, source: str) -> str:
         return f'''
-        You are comparing the quality of two responses to a user's query. Source
-        text that is supposedly relevant to the user's query is also provided
-        to you as a reference (the source text may contain some duplication).
-        Here is the data:
+        ユーザーの質問に対する2つの回答の品質を比較してください。ユーザーの質問に関連があると
+        思われるソーステキストも参考として提供されます（ソーステキストには重複が含まれている
+        可能性があります）。データは以下の通りです:
         [BEGIN DATA]
         ************
-        [User Query]: {user_query}
+        [ユーザーの質問]: {user_query}
         ************
-        [Source]: {source}
+        [ソース]: {source}
         ************
         [Response A]: {gen_output_a}
         ************
@@ -154,35 +148,32 @@ def pairwise_comparison(
         ************
         [END DATA]
 
-        Determine which of the responses is a better response to the user's
-        query. Consider factors such as helpfulness, correctness, and relevance
-        in your assessment, using the provided Source as a reference. Do not
-        allow the order in which the responses were presented to influence your
-        assessment. Do not allow the length of the responses to influence your
-        assessment. The available assessments are:
-        `Response A` - Response A is a better response.
-        `Response B` - Response B is a better response.
-        `Tie` - The two responses are roughly equal in quality.
+        ユーザーの質問に対してどちらの回答がより良いかを決定してください。提供されたソースを
+        参考にして、有用性、正確さ、関連性などの要素を考慮して評価してください。回答が提示された
+        順序に評価が影響されないようにしてください。回答の長さが評価に影響を与えないように
+        してください。利用可能な評価は以下の通りです:
+        `Response A` - Response Aがより良い回答です。
+        `Response B` - Response Bがより良い回答です。
+        `Tie` - 2つの回答は品質がほぼ同等です。
 
-        Take a deep breath and work on this problem step-by-step.
+        深呼吸をして、この問題をステップバイステップで取り組んでください。
         '''
 
     def _prompt_with_source_and_reference(gen_output_a: str, gen_output_b: str,
                                           user_query: str, ref_output: str,
                                           source: str) -> str:
         return f'''
-        You are comparing the quality of two responses to a user's query. Source
-        text that is supposedly relevant to the user's query is also provided
-        to you as a reference (the source text may contain some duplication).
-        The ideal response to the user's query is also provided to you as a
-        reference. Here is the data:
+        ユーザーの質問に対する2つの回答の品質を比較してください。ユーザーの質問に関連があると
+        思われるソーステキストも参考として提供されます（ソーステキストには重複が含まれている
+        可能性があります）。さらに、ユーザーの質問に対する理想的な回答も参考として提供されます。
+        データは以下の通りです:
         [BEGIN DATA]
         ************
-        [User Query]: {user_query}
+        [ユーザーの質問]: {user_query}
         ************
-        [Source]: {source}
+        [ソース]: {source}
         ************
-        [Ideal Response]: {ref_output}
+        [理想的な回答]: {ref_output}
         ************
         [Response A]: {gen_output_a}
         ************
@@ -190,17 +181,15 @@ def pairwise_comparison(
         ************
         [END DATA]
 
-        Determine which of the responses is a better response to the user's
-        query. Consider factors such as helpfulness, correctness, and relevance
-        in your assessment, using the provided Source and the Ideal Response as
-        references. Do not allow the order in which the responses were presented
-        to influence your assessment. Do not allow the length of the responses
-        to influence your assessment. The available assessments are:
-        `Response A` - Response A is a better response.
-        `Response B` - Response B is a better response.
-        `Tie` - The two responses are roughly equal in quality.
+        ユーザーの質問に対してどちらの回答がより良いかを決定してください。提供されたソースと
+        理想的な回答を参考に、有用性、正確さ、関連性などの要素を考慮して評価してください。
+        回答が提示された順序に評価が影響されないようにしてください。回答の長さが評価に影響を
+        与えないようにしてください。利用可能な評価は以下の通りです:
+        `Response A` - Response Aがより良い回答です。
+        `Response B` - Response Bがより良い回答です。
+        `Tie` - 2つの回答は品質がほぼ同等です。
 
-        Take a deep breath and work on this problem step-by-step.
+        深呼吸をして、この問題をステップバイステップで取り組んでください。
         '''
 
     def _function_call_prompt(long_assessment: str) -> str:

--- a/src/langcheck/metrics/ja/pairwise_text_quality.py
+++ b/src/langcheck/metrics/ja/pairwise_text_quality.py
@@ -236,8 +236,13 @@ def pairwise_comparison(
         all_swapped_prompts = prompt_generator.generate_prompts(
             generated_outputs_b, generated_outputs_a, prompts, sources_b,
             sources_a, reference_outputs)
+        intermediate_tqdm = '[Swapped model outputs order] Intermediate assessments (1/2)'  # NOQA: E501
+        score_tqdm = '[Swapped model outputs order] Calculating scores (2/2)'
         swapped_scores, swapped_explanations = oai_evaluator.get_score(
-            all_swapped_prompts, _function_call_prompt)
+            all_swapped_prompts,
+            _function_call_prompt,
+            intermediate_tqdm_description=intermediate_tqdm,
+            score_tqdm_description=score_tqdm)
         scores, explanations = enforce_pairwise_comparison_consistency(
             scores, explanations, swapped_scores, swapped_explanations)
 

--- a/src/langcheck/metrics/ja/pairwise_text_quality.py
+++ b/src/langcheck/metrics/ja/pairwise_text_quality.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from openai import OpenAI
+
+from langcheck.metrics._pairwise_text_quality_utils import (
+    PairwiseComparisonPromptGenerator, enforce_pairwise_comparison_consistency)
+from langcheck.metrics._validation import \
+    validate_parameters_pairwise_comparison
+from langcheck.metrics.en._openai import OpenAIBasedEvaluator
+from langcheck.metrics.metric_value import MetricValue
+
+
+def pairwise_comparison(
+    generated_outputs_a: List[str] | str,
+    generated_outputs_b: List[str] | str,
+    prompts: List[str] | str,
+    sources_a: Optional[List[str] | str] = None,
+    sources_b: Optional[List[str] | str] = None,
+    reference_outputs: Optional[List[str] | str] = None,
+    enforce_consistency: bool = True,
+    model_type: str = 'openai',
+    openai_client: Optional[OpenAI] = None,
+    openai_args: Optional[Dict[str,
+                               str]] = None) -> MetricValue[Optional[float]]:
+    '''Calculates the pairwise comparison metric. This metric takes on float
+    values of either 0.0 (Response A is better), 0.5 (Tie), or 1.0 (Response B
+    is better). The score may also be `None` if it could not be computed.
+
+    We currently support two model types:
+
+    1. The 'openai' type, where we use OpenAI's 'gpt-turbo-3.5' model
+    by default. While the model you use is configurable, please make sure to use
+    one that supports function calling
+    (https://platform.openai.com/docs/guides/gpt/function-calling). See
+    `this page <https://langcheck.readthedocs.io/en/latest/metrics.html
+    #computing-metrics-with-openai-models>`__
+    for examples on setting up the OpenAI API key.
+
+    2. The 'azure_openai' type. Essentially the same as the 'openai' type,
+    except that it uses the AzureOpenAI client. Note that you must specify your
+    model deployment to use in ``openai_args``, e.g.
+    ``openai_args={'model': 'YOUR_DEPLOYMENT_NAME'}``
+
+    Ref:
+        Our prompt is similar to the prompt used in
+        https://arxiv.org/abs/2306.05685
+
+    Args:
+        generated_outputs_a: Model A's generated output(s) to evaluate
+        generated_outputs_b: Model B's generated output(s) to evaluate
+        prompts: The prompts used to generate the output(s)
+        sources_a: The source text(s) for Model A's generated output(s), default
+            None
+        sources_b: The source text(s) for Model B's generated output(s), default
+            None
+        reference_outputs: The reference output(s), default None
+        enforce_consistency: When this is True, we will only return a score if
+            the score is the same when Model A and Model B are swapped. This is
+            useful for ensuring that the evaluator's position bias is not
+            impacting the scores. Default True.
+        model_type: The type of model to use ('openai', or 'azure_openai'),
+            default 'openai'
+        openai_client: OpenAI or AzureOpenAI client, default None. If this is
+            None, we will attempt to create a default client.
+        openai_args: Dict of additional args to pass in to the
+            ``client.chat.completions.create`` function, default None
+
+    Returns:
+        An MetricValue object
+    '''
+    generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b, reference_outputs = validate_parameters_pairwise_comparison(  # NOQA: E501
+        generated_outputs_a, generated_outputs_b, prompts, sources_a, sources_b,
+        reference_outputs)
+    assert model_type in [
+        'openai', 'azure_openai'
+    ], ('Unsupported model type. '
+        'The supported ones are ["openai", "azure_openai"]')
+
+    def _prompt(gen_output_a: str, gen_output_b: str, user_query: str) -> str:
+        return f'''
+        You are comparing the quality of two responses to a user's query. Here
+        is the data:
+        [BEGIN DATA]
+        ************
+        [User Query]: {user_query}
+        ************
+        [Response A]: {gen_output_a}
+        ************
+        [Response B]: {gen_output_b}
+        ************
+        [END DATA]
+
+        Determine which of the responses is a better response to the user's
+        query. Consider factors such as helpfulness, correctness, and relevance
+        in your assessment. Do not allow the order in which the responses were
+        presented to influence your assessment. Do not allow the length of the
+        responses to influence your assessment. The available assessments are:
+        `Response A` - Response A is a better response.
+        `Response B` - Response B is a better response.
+        `Tie` - The two responses are roughly equal in quality.
+
+        Take a deep breath and work on this problem step-by-step.
+        '''
+
+    def _prompt_with_reference(gen_output_a: str, gen_output_b: str,
+                               user_query: str, ref_output: str) -> str:
+        return f'''
+        You are comparing the quality of two responses to a user's query. The
+        ideal response to the user's query is also provided to you as a
+        reference. Here is the data:
+        [BEGIN DATA]
+        ************
+        [User Query]: {user_query}
+        ************
+        [Ideal Response]: {ref_output}
+        ************
+        [Response A]: {gen_output_a}
+        ************
+        [Response B]: {gen_output_b}
+        ************
+        [END DATA]
+
+        Determine which of the responses is a better response to the user's
+        query. Consider factors such as helpfulness, correctness, and relevance
+        in your assessment, using the provided Ideal Response as a reference. Do
+        not allow the order in which the responses were presented to influence
+        your assessment. Do not allow the length of the responses to influence
+        your assessment. The available assessments are:
+        `Response A` - Response A is a better response.
+        `Response B` - Response B is a better response.
+        `Tie` - The two responses are roughly equal in quality.
+
+        Take a deep breath and work on this problem step-by-step.
+        '''
+
+    def _prompt_with_source(gen_output_a: str, gen_output_b: str,
+                            user_query: str, source: str) -> str:
+        return f'''
+        You are comparing the quality of two responses to a user's query. Source
+        text that is supposedly relevant to the user's query is also provided
+        to you as a reference (the source text may contain some duplication).
+        Here is the data:
+        [BEGIN DATA]
+        ************
+        [User Query]: {user_query}
+        ************
+        [Source]: {source}
+        ************
+        [Response A]: {gen_output_a}
+        ************
+        [Response B]: {gen_output_b}
+        ************
+        [END DATA]
+
+        Determine which of the responses is a better response to the user's
+        query. Consider factors such as helpfulness, correctness, and relevance
+        in your assessment, using the provided Source as a reference. Do not
+        allow the order in which the responses were presented to influence your
+        assessment. Do not allow the length of the responses to influence your
+        assessment. The available assessments are:
+        `Response A` - Response A is a better response.
+        `Response B` - Response B is a better response.
+        `Tie` - The two responses are roughly equal in quality.
+
+        Take a deep breath and work on this problem step-by-step.
+        '''
+
+    def _prompt_with_source_and_reference(gen_output_a: str, gen_output_b: str,
+                                          user_query: str, ref_output: str,
+                                          source: str) -> str:
+        return f'''
+        You are comparing the quality of two responses to a user's query. Source
+        text that is supposedly relevant to the user's query is also provided
+        to you as a reference (the source text may contain some duplication).
+        The ideal response to the user's query is also provided to you as a
+        reference. Here is the data:
+        [BEGIN DATA]
+        ************
+        [User Query]: {user_query}
+        ************
+        [Source]: {source}
+        ************
+        [Ideal Response]: {ref_output}
+        ************
+        [Response A]: {gen_output_a}
+        ************
+        [Response B]: {gen_output_b}
+        ************
+        [END DATA]
+
+        Determine which of the responses is a better response to the user's
+        query. Consider factors such as helpfulness, correctness, and relevance
+        in your assessment, using the provided Source and the Ideal Response as
+        references. Do not allow the order in which the responses were presented
+        to influence your assessment. Do not allow the length of the responses
+        to influence your assessment. The available assessments are:
+        `Response A` - Response A is a better response.
+        `Response B` - Response B is a better response.
+        `Tie` - The two responses are roughly equal in quality.
+
+        Take a deep breath and work on this problem step-by-step.
+        '''
+
+    def _function_call_prompt(long_assessment: str) -> str:
+        return f'''
+        The following is an assessment on whether Response A or Response B is
+        the better response to the user's query:
+        ************
+        [Assessment]: {long_assessment}
+        ************
+
+        Save the resulting assessment. The available assessments are:
+        `Response A`
+        `Response B`
+        `Tie`
+        '''
+
+    pairwise_comparison_assessment_to_score = {
+        'Response B': 1.0,
+        'Tie': 0.5,
+        'Response A': 0.0
+    }
+    oai_evaluator = OpenAIBasedEvaluator(
+        assessment_to_score_mapping=pairwise_comparison_assessment_to_score,
+        function_name='save_pairwise_comparison_assessment',
+        function_description=("Saves a pairwise comparison assessment."),
+        argument_name='pairwise_comparison',
+        argument_description='The pairwise comparison assessment',
+        client_type=model_type,
+        client=openai_client,
+        openai_args=openai_args)
+
+    prompt_generator = PairwiseComparisonPromptGenerator(
+        _prompt, _prompt_with_reference, _prompt_with_source,
+        _prompt_with_source_and_reference)
+    all_prompts = prompt_generator.generate_prompts(generated_outputs_a,
+                                                    generated_outputs_b,
+                                                    prompts, sources_a,
+                                                    sources_b,
+                                                    reference_outputs)
+    scores, explanations = oai_evaluator.get_score(all_prompts,
+                                                   _function_call_prompt)
+
+    if enforce_consistency:
+        # Swap the generated outputs and enforce consistency
+        all_swapped_prompts = prompt_generator.generate_prompts(
+            generated_outputs_b, generated_outputs_a, prompts, sources_b,
+            sources_a, reference_outputs)
+        swapped_scores, swapped_explanations = oai_evaluator.get_score(
+            all_swapped_prompts, _function_call_prompt)
+        scores, explanations = enforce_pairwise_comparison_consistency(
+            scores, explanations, swapped_scores, swapped_explanations)
+
+    return MetricValue(metric_name='pairwise_comparison',
+                       prompts=prompts,
+                       generated_outputs=(generated_outputs_a,
+                                          generated_outputs_b),
+                       reference_outputs=reference_outputs,
+                       sources=(sources_a, sources_b),
+                       explanations=explanations,
+                       metric_values=scores,
+                       language='ja')

--- a/tests/metrics/ja/test_pairwise_text_quality.py
+++ b/tests/metrics/ja/test_pairwise_text_quality.py
@@ -1,0 +1,121 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from openai.types.chat import ChatCompletion
+
+from langcheck.metrics.ja.pairwise_text_quality import pairwise_comparison
+
+################################################################################
+# Tests
+################################################################################
+
+
+@pytest.mark.parametrize(
+    'generated_outputs_a,generated_outputs_b,prompts,sources_a,sources_b,reference_outputs',  # NOQA: E501
+    [("東京は日本の首都です。", "ニューヨークは日本の首都です。", '日本の首都は何ですか？', None, None, None),
+     ("東京は日本の首都です。", "ニューヨークは日本の首都です。", '日本の首都は何ですか？', None, None, '東京'),
+     ("東京は日本の首都です。", "ニューヨークは日本の首都です。", '日本の首都は何ですか？', '日本の首都 = 東京', None,
+      None),
+     ("東京は日本の首都です。", "ニューヨークは日本の首都です。", '日本の首都は何ですか？', '日本の首都 = 東京',
+      '日本の首都 = 東京', None),
+     ("東京は日本の首都です。", "ニューヨークは日本の首都です。", '日本の首都は何ですか？', '日本の首都 = 東京',
+      '日本の首都 = 東京', '東京')])
+def test_pairwise_comparison_openai(generated_outputs_a, generated_outputs_b,
+                                    prompts, sources_a, sources_b,
+                                    reference_outputs):
+    '''Test the pairwise_comparison function.
+
+    Test 1: No sources or reference outputs are provided.
+    Test 2: Reference output is provided.
+    Test 3: Source A is provided.
+    Test 4: Both Source A and Source B are provided.
+    Test 5: Source A, Source B, and the reference output are provided.
+    '''
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(function_call=Mock(
+            arguments="{\n  \"pairwise_comparison\": \"Tie\"\n}")))
+    ]
+
+    # Calling the openai.resources.chat.Completions.create method requires an
+    # OpenAI API key, so we mock the return value instead
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='openai')
+        # "Tie" gets a value of 0.5
+        assert metric_value == 0.5
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='azure_openai',
+                                           openai_args={'model': 'foo bar'})
+        # "Tie" gets a value of 0.5
+        assert metric_value == 0.5
+
+
+@pytest.mark.parametrize(
+    'generated_outputs_a,generated_outputs_b,prompts,sources_a,sources_b,reference_outputs',  # NOQA: E501
+    [("東京は日本の首都です。", "ニューヨークは日本の首都です。", '日本の首都は何ですか？', None, None, None)])
+def test_pairwise_comparison_inconsistency_openai(generated_outputs_a,
+                                                  generated_outputs_b, prompts,
+                                                  sources_a, sources_b,
+                                                  reference_outputs):
+    '''Test the pairwise_comparison function when inconsistent scores are
+    returned when Model A and Model B are swapped.
+    '''
+    # If Response A is selected for both the original order (Model A vs. Model
+    # B) and the swapped order (Model B vs. Model A), then the results are
+    # inconsistent.
+    mock_chat_completion = Mock(spec=ChatCompletion)
+    mock_chat_completion.choices = [
+        Mock(message=Mock(function_call=Mock(
+            arguments="{\n  \"pairwise_comparison\": \"Response A\"\n}")))
+    ]
+
+    # Calling the openai.resources.chat.Completions.create method requires an
+    # OpenAI API key, so we mock the return value instead
+    with patch('openai.resources.chat.Completions.create',
+               return_value=mock_chat_completion):
+        # Set the necessary env vars for the 'openai' model type
+        os.environ["OPENAI_API_KEY"] = "dummy_key"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='openai')
+        # The score should be None if the results are inconsistent
+        assert metric_value.metric_values[0] is None
+
+        # Set the necessary env vars for the 'azure_openai' model type
+        os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
+        os.environ["OPENAI_API_VERSION"] = "dummy_version"
+        os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
+        metric_value = pairwise_comparison(generated_outputs_a,
+                                           generated_outputs_b,
+                                           prompts,
+                                           sources_a=sources_a,
+                                           sources_b=sources_b,
+                                           reference_outputs=reference_outputs,
+                                           model_type='azure_openai',
+                                           openai_args={'model': 'foo bar'})
+        # The score should be None if the results are inconsistent
+        assert metric_value.metric_values[0] is None


### PR DESCRIPTION
- Refactored language agnostic logic of the `pairwise_comparison` metric into `src/langcheck/metrics/_pairwise_text_quality_utils.py`
- Implemented `pairwise_comparison` for `ja` with prompts in Japanese
- Enabled async for `pairwise_comparison` (both en and ja)