### PR TITLE
Increment version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.5.0"
+version = "0.6.0"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]


### PR DESCRIPTION
Increment the version number in preparation for the 0.6.0 release. Draft release notes [here](https://github.com/citadel-ai/langcheck/releases/tag/untagged-6f4c5faa3c8fcefe6db6).