### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,33 +4,29 @@
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.8-bullseye",
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// PyTorch 2.1.0 causes segmentation fault in aarch64, so we pin the version in the dev container until the bug is fixed.
 	// Ref: https://github.com/pytorch/pytorch/issues/110819
-	"postCreateCommand": "pip install --upgrade pip && pip install yapf==0.40.1 && python -m pip install -e .[all,dev] && pip install torch==2.0.1",
-
+	"postCreateCommand": "curl https://sh.rustup.rs -sSf | bash -s -- -y && . $HOME/.cargo/env && pip install --upgrade pip && pip install yapf==0.40.1 && python -m pip install -e .[all,dev] && pip install torch==2.0.1",
 	"customizations": {
-    // Configure properties specific to VS Code.
-    "vscode": {
-      // Add the IDs of extensions you want installed when the container is created.
-      "extensions": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"ms-python.flake8",
-		"ms-python.isort",
-		"eeyore.yapf",
-		"GitHub.vscode-pull-request-github",
-		"ms-azuretools.vscode-docker",
-		"shardulm94.trailing-spaces",
-		"ms-toolsai.jupyter"
-	]
-    }
-  }
-
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.flake8",
+				"ms-python.isort",
+				"eeyore.yapf",
+				"GitHub.vscode-pull-request-github",
+				"ms-azuretools.vscode-docker",
+				"shardulm94.trailing-spaces",
+				"ms-toolsai.jupyter"
+			]
+		}
+	}
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -65,13 +65,20 @@ In this case, you need have a Rust compiler in your environment so that the pack
 
 Follow the [official documentation](https://www.rust-lang.org/tools/install) and install Rust before installing `langcheck`.
 
-### 3. The error `AttributeError: module 'langcheck.metrics' has no attribute 'ja'`
+If you do not need the `[ja-optional]` dependencies, you can also install each language individually by
+
+```sh
+pip install langcheck[en,ja,de,zh]
+```
+
+
+### 4. The error `AttributeError: module 'langcheck.metrics' has no attribute 'ja'`
 
 If you see this error when calling a LangCheck function, such as `langcheck.metrics.ja.toxicity()`, you probably need to install the Japanese LangCheck package.
 
 Run `pip install langcheck[ja]` (or for your required language) and try again.
 
-### 4. The error `ModuleNotFoundError`
+### 5. The error `ModuleNotFoundError`
 
 If you see this error when importing a LangCheck package, such as `import langcheck.metrics.ja`, you probably need to install the Japanese LangCheck package.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,6 +58,13 @@ Most systems already have `gcc` installed, with the exception of "slim" Docker i
 1. Use `python:3.11-buster` instead of `python:3.11-slim-buster`, which includes gcc.
 1. Run `apt update && apt install build-essential -y` (e.g. in your Dockerfile) to install gcc.
 
+### 3. The error message `Failed to build sudachipy`
+
+The `sudachipy` package, which is installed with `langcheck[all]` or `langcheck[ja-optional]`, does not have a pre-built wheel for ARM64 Linux devices.
+In this case, you need have a Rust compiler in your environment so that the package can be built in the local environment.
+
+Follow the [official documentation](https://www.rust-lang.org/tools/install) and install Rust before installing `langcheck`.
+
 ### 3. The error `AttributeError: module 'langcheck.metrics' has no attribute 'ja'`
 
 If you see this error when calling a LangCheck function, such as `langcheck.metrics.ja.toxicity()`, you probably need to install the Japanese LangCheck package.


### PR DESCRIPTION
The `postCreateCommand` of our default VSCode dev container was failing because the container was missing `cargo`, which is required by some libraries in `langcheck[ja-optional]` dependencies. Fixed this problem and re-formatted the `devcontainer.json` file.