### PR TITLE
Fix docs for eval_client

### DIFF
--- a/docs/langcheck.metrics.eval_clients.rst
+++ b/docs/langcheck.metrics.eval_clients.rst
@@ -1,0 +1,10 @@
+
+
+
+langcheck.metrics.eval\_clients
+===============================
+
+.. automodule:: langcheck.metrics.eval_clients
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.ja.pairwise_text_quality.rst
+++ b/docs/langcheck.metrics.ja.pairwise_text_quality.rst
@@ -1,0 +1,8 @@
+
+langcheck.metrics.ja.pairwise\_text\_quality
+============================================
+
+.. automodule:: langcheck.metrics.ja.pairwise_text_quality
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.ja.rst
+++ b/docs/langcheck.metrics.ja.rst
@@ -16,6 +16,7 @@ langcheck.metrics.ja
    :hidden:
    :maxdepth: 4
 
+   langcheck.metrics.ja.pairwise_text_quality
    langcheck.metrics.ja.reference_based_text_quality
    langcheck.metrics.ja.reference_free_text_quality
    langcheck.metrics.ja.source_based_text_quality

--- a/docs/langcheck.metrics.rst
+++ b/docs/langcheck.metrics.rst
@@ -56,6 +56,7 @@ There are several different types of metrics:
 
    langcheck.metrics.de
    langcheck.metrics.en
+   langcheck.metrics.eval_clients
    langcheck.metrics.ja
    langcheck.metrics.zh
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -87,13 +87,11 @@ An example metric is {func}`~langcheck.metrics.en.pairwise_text_quality.pairwise
 (computing-metrics-with-remote-llms)=
 ### Computing Metrics with Remote LLMs
 
-Several text quality metrics are computed using a model (e.g. `toxicity`, `sentiment`, `semantic_similarity`, `factual_consistency`). By default, LangCheck will download and use a model that can run locally on your machine (often from HuggingFace) so that the metric function works with no additional setup.
+Several text quality metrics are computed using a machine learning model (e.g. `toxicity`, `semantic_similarity`, `factual_consistency`). By default, LangCheck will download and use a model that can run locally on your machine so that the metric works with no additional setup.
 
-However, if you would like to use a remote LLM such as the OpenAI API, you can also configure these metrics to use that model, which may provide more accurate
-results for more complex use cases. You need to pass an `~langcheck.metrics.eval_clients.EvalClient` instance corresponding to the service you use to the
-metric functions.
+However, you can also configure LangCheck's metrics to use a remotely-hosted LLM, such as OpenAI/Gemini/Claude, which may provide better evaluations for complex text. To do this, you need to provide the appropriate {class}`~langcheck.metrics.eval_clients.EvalClient` instance, such as {class}`~langcheck.metrics.eval_clients.OpenAIEvalClient`, to the metric function.
 
-Here are some examples of how to do this:
+Here's an example for the OpenAI API:
 
 ```python
 import os
@@ -121,7 +119,7 @@ similarity_value = semantic_similarity(generated_outputs,
                                        eval_model=eval_client)
 ```
 
-Or, if you're using Azure OpenAI, here are some examples of how to use it:
+Or, another example for the Azure OpenAI API:
 
 ```python
 import os

--- a/src/langcheck/metrics/eval_clients/_base.py
+++ b/src/langcheck/metrics/eval_clients/_base.py
@@ -7,8 +7,8 @@ from ..scorer._base import BaseSimilarityScorer
 
 class EvalClient:
     '''An abstract class that defines the interface for the evaluation clients.
-    Most of metrics that uses external APIs such as OpenAI API calls the
-    functions defined in this class to do the evaluation.
+    Most metrics that use external APIs such as OpenAI API call the methods
+    defined in this class to compute the metric values.
     '''
 
     def get_text_responses(
@@ -38,12 +38,15 @@ class EvalClient:
             *,
             tqdm_description: str | None = None) -> list[float | None]:
         '''The function that transforms the unstructured assessments (i.e. long
-        texts that describe the evaluation results) into scores. Typical
-        workflow can be
+        texts that describe the evaluation results) into scores. A typical
+        workflow can be:
+
         1. Extract a short assessment result strings from the unstructured
-            assessment results.
+        assessment results.
+
         2. Map the short assessment result strings to the scores using the
-            score_map.
+        score_map.
+
         Each concrete subclass needs to define the concrete implementation of
         this function to enable text scoring.
 


### PR DESCRIPTION
Noticed a few minor issues in the docs when reviewing release notes. The eval_client docs were missing since we didn't run the `sphinx-apidoc` command after adding new modules.