### PR TITLE
Custom evaluator metric

### DIFF
--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -1,4 +1,5 @@
 from langcheck.metrics import en, eval_clients
+from langcheck.metrics.custom_text_quality import custom_evaluator
 from langcheck.metrics.en.pairwise_text_quality import pairwise_comparison
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1, rouge2, rougeL, semantic_similarity)
@@ -22,6 +23,7 @@ __all__ = [
     'contains_any_strings',
     'contains_regex',
     'context_relevance',
+    'custom_evaluator',
     'MetricValue',
     'en',
     'eval_clients',

--- a/src/langcheck/metrics/_validation.py
+++ b/src/langcheck/metrics/_validation.py
@@ -203,6 +203,51 @@ def validate_parameters_pairwise_comparison(
             _sources_b, _reference_outputs)
 
 
+def validate_parameters_custom_evaluator(
+    generated_outputs: Optional[List[str] | str],
+    prompts: Optional[List[str] | str],
+    reference_outputs: Optional[List[str] | str],
+    sources: Optional[List[str] | str]
+) -> tuple[Optional[List[str]], Optional[List[str]], Optional[List[str]],
+           Optional[List[str]]]:
+    '''Validates and parses function parameters for the custom evaluator metric.
+
+    Args:
+        generated_outputs: The model generated output(s)
+        prompts: The prompts used to generate the output(s)
+        reference_outputs: The reference output(s)
+        sources: The source(s) of the generated output(s)
+
+    Returns:
+        A tuple (generated_outputs, prompts, reference_outputs, sources) of the
+        parsed parameters. All non-None parameters are converted to lists of
+        strings.
+    '''
+    # Convert single-string parameters to lists
+    if isinstance(generated_outputs, str):
+        generated_outputs = [generated_outputs]
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    if isinstance(reference_outputs, str):
+        reference_outputs = [reference_outputs]
+    if isinstance(sources, str):
+        sources = [sources]
+
+    # Check that all of the non-None parameters are the same length
+    non_none_lengths = {
+        name: len(arg)
+        for name, arg in
+        zip(['generated outputs', 'prompts', 'reference outputs', 'sources'],
+            [generated_outputs, prompts, reference_outputs, sources])
+        if arg is not None
+    }
+    if len(set(non_none_lengths.values())) > 1:
+        raise ValueError(
+            f'The number of {", ".join(non_none_lengths.keys())} do not match')
+
+    return generated_outputs, prompts, reference_outputs, sources
+
+
 def _validate_parameters(
     generated_outputs: List[str] | str, prompts: Optional[List[str] | str],
     reference_outputs: Optional[List[str] | str],

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -20,6 +20,22 @@ def custom_evaluator(generated_outputs: list[str] | str | None,
     assess the provided inputs using the prompt template, and then convert those
     assessments into scores using the score map.
 
+    The prompt template should be a Jinja2 file (file extension .j2) that
+    specifies the criteria that an LLM (as configured in the Eval Client) should
+    follow when evaluating an instance. The template is allowed to have
+    placeholders for the following variables (NOTE: not all are required):
+    - `gen_output`: The generated output
+    - `user_query`: The prompt
+    - `src`: The source text
+    - `ref_output`: The reference output
+
+    The prompt template should also specify the final available assessments for
+    the LLM evaluator, e.g. "Good", "Bad", "Neutral", etc. The score map should
+    then map each of those available assessments to a numerical score. E.g. if
+    the available assessments in the prompt template are "Good", "Bad", and
+    "Neutral", the score map should be something like:
+    ``score_map = {'Good': 1.0, 'Neutral': 0.5, 'Bad': 0.0}``
+
     Args:
         generated_outputs: The model generated output(s)
         prompts: The prompts used to generate the output(s)
@@ -28,7 +44,8 @@ def custom_evaluator(generated_outputs: list[str] | str | None,
         eval_model: The EvalClient instance used for the evaluation
         metric_name: The name of the metric
         score_map: A dictionary mapping the evaluator's assessments to scores
-        template_path: The path to the prompt template file
+        template_path: The path to the prompt template file. This should be a
+            Jinja2 file (file extension .j2).
         language: The language that the evaluator will use ('en', 'ja', or 'de')
 
     Returns:

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -36,6 +36,12 @@ def custom_evaluator(generated_outputs: list[str] | str | None,
     "Neutral", the score map should be something like:
     ``score_map = {'Good': 1.0, 'Neutral': 0.5, 'Bad': 0.0}``
 
+    NOTE: We have found that LLM models sometimes behave weirdly when the
+    assessments are non-ascii characters (see
+    https://github.com/citadel-ai/langcheck/pull/84 as an example). So, we
+    recommend making the final assessments ascii characters, even when the rest
+    of the prompt template contains non-ascii characters (e.g. Japanese).
+
     Args:
         generated_outputs: The model generated output(s)
         prompts: The prompts used to generate the output(s)

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -48,6 +48,9 @@ def custom_evaluator(generated_outputs: list[str] | str | None,
 
     assert Path(template_path).exists(
     ), f'Prompt template file {template_path} does not exist.'
+    assert template_path.endswith('.j2'), \
+        'The prompt template file must be a Jinja2 template file with the extension ".j2"'  # NOQA: E501
+
     prompt_template_source = Path(template_path).read_text()
     prompt_template = Template(prompt_template_source)
 

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -26,7 +26,7 @@ def custom_evaluator(generated_outputs: list[str] | str | None,
          if lst is not None), 0)
 
     assert Path(template_path).exists(
-    ), f'Prompt template file {template_path} does not exist.'  # NOQA: E501
+    ), f'Prompt template file {template_path} does not exist.'
     prompt_template_source = Path(template_path).read_text()
     prompt_template = Template(prompt_template_source)
 

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -16,6 +16,24 @@ def custom_evaluator(generated_outputs: list[str] | str | None,
                      eval_model: EvalClient, metric_name: str,
                      score_map: dict[str, float], template_path: str,
                      language: str) -> MetricValue[float | None]:
+    '''Calculates the scores of a custom evaluator. The EvalClient will first
+    assess the provided inputs using the prompt template, and then convert those
+    assessments into scores using the score map.
+
+    Args:
+        generated_outputs: The model generated output(s)
+        prompts: The prompts used to generate the output(s)
+        sources: The source(s) of the generated output(s)
+        reference_outputs: The reference output(s)
+        eval_model: The EvalClient instance used for the evaluation
+        metric_name: The name of the metric
+        score_map: A dictionary mapping the evaluator's assessments to scores
+        template_path: The path to the prompt template file
+        language: The language that the evaluator will use ('en', 'ja', or 'de')
+
+    Returns:
+        A MetricValue object
+    '''
     generated_outputs, prompts, reference_outputs, sources = validate_parameters_custom_evaluator(  # NOQA: E501
         generated_outputs, prompts, reference_outputs, sources)
     # Find the length of the first non-None list (they are guaranteed to all be
@@ -24,6 +42,9 @@ def custom_evaluator(generated_outputs: list[str] | str | None,
         (len(lst)
          for lst in [generated_outputs, prompts, reference_outputs, sources]
          if lst is not None), 0)
+
+    if language not in ['en', 'ja', 'de']:
+        raise ValueError(f'Unsupported language: {language}')
 
     assert Path(template_path).exists(
     ), f'Prompt template file {template_path} does not exist.'

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from langcheck.metrics._validation import _validate_parameters
+from langcheck.metrics.eval_clients import EvalClient
+from langcheck.metrics.metric_value import MetricValue
+from langcheck.metrics.prompts._utils import get_custom_template
+
+
+def custom_evaluator(generated_outputs: list[str] | str,
+                     prompts: list[str] | str | None,
+                     sources: list[str] | str | None,
+                     reference_outputs: list[str] | str | None,
+                     eval_model: EvalClient, metric_name: str,
+                     score_map: dict[str, float], template_path: str,
+                     language: str) -> MetricValue[float | None]:
+    generated_outputs, prompts, reference_outputs, sources = _validate_parameters(  # NOQA: E501
+        generated_outputs, prompts, reference_outputs, sources)
+
+    prompt_template = get_custom_template(template_path)
+
+    def _args_to_prompt_param(generated_outputs, prompts, sources,
+                              reference_outputs, index):
+        prompt_param = {
+            'gen_output': generated_outputs[index],
+        }
+        if prompts is not None:
+            prompt_param['user_query'] = prompts[index]
+        if sources is not None:
+            prompt_param['src'] = sources[index]
+        if reference_outputs is not None:
+            prompt_param['ref_output'] = reference_outputs[index]
+        return prompt_param
+
+    populated_prompts = []
+    for i in range(len(generated_outputs)):
+        prompt_param = _args_to_prompt_param(generated_outputs, prompts,
+                                             sources, reference_outputs, i)
+        populated_prompts.append(prompt_template.render(prompt_param))
+
+    scores, explanations = eval_model.get_score(
+        metric_name=metric_name,
+        language=language,
+        prompts=populated_prompts,
+        score_map=score_map,
+    )
+
+    return MetricValue(metric_name=metric_name,
+                       prompts=prompts,
+                       generated_outputs=generated_outputs,
+                       reference_outputs=reference_outputs,
+                       sources=sources,
+                       explanations=explanations,
+                       metric_values=scores,
+                       language=language)

--- a/src/langcheck/metrics/prompts/_utils.py
+++ b/src/langcheck/metrics/prompts/_utils.py
@@ -15,11 +15,3 @@ def get_template(relative_path: str) -> Template:
     '''
     cwd = Path(__file__).parent
     return Template((cwd / relative_path).read_text())
-
-
-def get_custom_template(relative_path: str) -> Template:
-    '''
-    Gets a Jinja template from the specified prompt template file.
-    The path is given by the user.
-    '''
-    return Template(Path(relative_path).read_text())

--- a/src/langcheck/metrics/prompts/_utils.py
+++ b/src/langcheck/metrics/prompts/_utils.py
@@ -15,3 +15,11 @@ def get_template(relative_path: str) -> Template:
     '''
     cwd = Path(__file__).parent
     return Template((cwd / relative_path).read_text())
+
+
+def get_custom_template(relative_path: str) -> Template:
+    '''
+    Gets a Jinja template from the specified prompt template file.
+    The path is given by the user.
+    '''
+    return Template(Path(relative_path).read_text())

--- a/tests/metrics/test_custom_text_quality.py
+++ b/tests/metrics/test_custom_text_quality.py
@@ -1,0 +1,39 @@
+import tempfile
+
+import pytest
+
+from langcheck.metrics import custom_evaluator
+from tests.utils import MockEvalClient
+
+################################################################################
+# Tests
+################################################################################
+
+
+@pytest.mark.parametrize(
+    'generated_outputs,sources',
+    [('Tokyo is the capital of Japan.', "Tokyo is Japan's capital city."),
+     (['Tokyo is the capital of Japan.', 'The Earth is flat.'
+      ], ["Tokyo is Japan's capital city.", 'The Earth is round.'])])
+def test_custom_evaluator(generated_outputs, sources):
+    metric_name = 'factual consistency'
+    score_map = {
+        'Fully Consistent': 1.0,
+        'Partially Consistent': 0.5,
+        'Not Consistent': 0.0
+    }
+    # Create a temporary Jinja2 template file
+    with tempfile.NamedTemporaryFile(suffix=".j2") as temp:
+        temp.write(b'''
+        Evaluate the submitted claim's factual consistency with the source:
+        [Source]: {{ src }}
+        [Submission]: {{ gen_output }}
+        ''')
+        template_path = temp.name
+
+        for option in score_map:
+            eval_client = MockEvalClient(option)
+            metric_value = custom_evaluator(generated_outputs, None, sources,
+                                            None, eval_client, metric_name,
+                                            score_map, template_path, 'en')
+            assert metric_value == score_map[option]


### PR DESCRIPTION
Adds a `custom_evaluator` metric that allows users to specify a custom prompt-based metric.

E.g. you can create your own "Answer Conciseness" metric by first writing a prompt template in a jinja file:
```
You are evaluating the conciseness of the answer to a user's query. Here is the data:
[BEGIN DATA]
************
[User Query]: {{ user_query }}
************
[Answer]: {{ gen_output }}
************
[END DATA]

Determine whether the answer is a concise response to the user's query.
The available assessments are:
`Concise` - The answer is a concise response to the user's query that is short and to the point.
`Not Concise` - The answer is not a concise response to the user's query, e.g. there are unnecessary details or the answer is too long.

Write out a one-sentence justification before giving the final assessment.
```

And then, you can compute the metric like this:
```
# Create an eval_client as usual

gen_output = [
    '4',
    'The answer to the question 2+2 is 4. If you need any more assistance with math, feel free to ask!'
]
prompt = ['what is 2+2?', 'what is 2+2?']

score_map = {'Not Concise': 0.0, 'Concise': 1.0}

langcheck.metrics.custom_evaluator(generated_outputs=gen_output,
                                   prompts=prompt,
                                   sources=None,
                                   reference_outputs=None,
                                   eval_model=eval_client,
                                   metric_name='answer_conciseness',
                                   score_map=score_map,
                                   template_path='answer_conciseness.j2',
                                   language='en')
```
<img width="1157" alt="image" src="https://github.com/citadel-ai/langcheck/assets/107823399/6aa2c192-66be-4089-a706-72b24b787c35">
