### PR TITLE
Bump version to 0.8.0.dev2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.8.0.dev1"
+version = "0.8.0.dev2"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]


### PR DESCRIPTION
Bumps the version to 0.8.0.dev2. This is a pre-release, so pip will ignore it by default (https://pip.pypa.io/en/stable/cli/pip_install/#pre-release-versions).