### PR TITLE
Handle `None` sources in the pairwise comparison metric

### DIFF
--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -34,6 +34,14 @@ def generate_pairwise_comparison_prompt_params(
     # Combine sources_1 and sources_2 into a single list if both are
     # provided.
     if sources_1 is not None and sources_2 is not None:
+        sources = []
+        for source_1, source_2 in zip(sources_1, sources_2):
+            if source_1 is None:
+                sources.append(source_2)
+            elif source_2 is None:
+                sources.append(source_1)
+            else:
+                sources.append(source_1 + '\n' + source_2)
         sources = [
             source_1 + '\n' + source_2
             for source_1, source_2 in zip(sources_1, sources_2)

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -42,10 +42,6 @@ def generate_pairwise_comparison_prompt_params(
                 sources.append(source_1)
             else:
                 sources.append(source_1 + '\n' + source_2)
-        sources = [
-            source_1 + '\n' + source_2
-            for source_1, source_2 in zip(sources_1, sources_2)
-        ]
     else:
         sources = sources_1 if sources_1 is not None else sources_2
 


### PR DESCRIPTION
The line `source_1 + '\n' + source_2` causes an error if one (or both) of the elements in the sources lists are `None`. With this fix, we will now properly handle this case.

Here's a random snippet for testing:
```
gen_output1 = ["hello", "how are you"]
gen_output2 = ["blah", "blah blah"]
ref_output = [None, "how are you"]
# source1 = ["say hello", "ask how are you"]
source1 = ["say hello", None]
# source2 = ["blah", "blah blah"]
source2 = [None, "blah blah"]
prompts = ["hello", "hi"]

ret = langcheck.metrics.pairwise_comparison(
    gen_output1, gen_output2, prompts, source1, source2, ref_output,
    eval_model=eval_client
)
```