### PR TITLE
Return `None` if the function calling step returns an invalid assessment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.8.0.dev2"
+version = "0.8.0.dev3"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -198,7 +198,8 @@ class GeminiEvalClient(EvalClient):
             print(f'Gemini returned an unrecognized assessment: "{assessment}"')
 
         return [
-            score_map[assessment] if assessment else None
+            score_map[assessment]
+            if assessment and assessment in options else None
             for assessment in assessments
         ]
 

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -216,7 +216,8 @@ class OpenAIEvalClient(EvalClient):
             print(f'OpenAI returned an unrecognized assessment: "{assessment}"')
 
         return [
-            score_map[assessment] if assessment else None
+            score_map[assessment]
+            if assessment and assessment in options else None
             for assessment in assessments
         ]
 


### PR DESCRIPTION
Updates the eval clients to set a metric value to `None` in the rare case that the function calling step returns an invalid assessment. Otherwise, the evaluator will fail with a KeyError.

(I tried for a bit to trigger a bad assessment but couldn't get it to happen 😅)

Also bump the version to `0.8.0.dev3`