### PR TITLE
Custom pairwise evaluator metric

### DIFF
--- a/src/langcheck/metrics/__init__.py
+++ b/src/langcheck/metrics/__init__.py
@@ -1,5 +1,8 @@
 from langcheck.metrics import en, eval_clients
-from langcheck.metrics.custom_text_quality import custom_evaluator
+from langcheck.metrics.custom_text_quality import (
+    custom_evaluator,
+    custom_pairwise_evaluator,
+)
 from langcheck.metrics.en.pairwise_text_quality import pairwise_comparison
 from langcheck.metrics.en.reference_based_text_quality import (
     rouge1,
@@ -42,6 +45,7 @@ __all__ = [
     "contains_regex",
     "context_relevance",
     "custom_evaluator",
+    "custom_pairwise_evaluator",
     "MetricValue",
     "en",
     "eval_clients",

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -81,6 +81,7 @@ def enforce_pairwise_comparison_consistency(
     original_explanations: list[str | None],
     swapped_scores: list[float | None],
     swapped_explanations: list[str | None],
+    score_map: dict[str, float],
 ) -> tuple[list[float | None], list[str | None]]:
     """Enforce consistency in pairwise comparison scores.
 
@@ -91,8 +92,18 @@ def enforce_pairwise_comparison_consistency(
         swapped_scores: The scores for the swapped order of the models
         swapped_explanations: The explanations for the swapped order of the
             models
+        score_map: The mapping from the assessment results to the scores (e.g.
+            {'Response A': 0.0, 'Response B': 1.0, 'Tie': 0.5})
     """
-    # Iterate through the scores and explanations to check for consistency.
+    # Get the sorted list of available scores
+    sorted_available_scores = list(score_map.values())
+    sorted_available_scores.sort()
+
+    # Iterate through the scores and explanations to check for consistency. A
+    # score is consistent if the score's index in the sorted_available_scores
+    # list is the inverse of the swapped score's index. For example, if the
+    # score_map is {'Response A': 0.0, 'Response B': 1.0, 'Tie': 0.5}, and the
+    # score is 0.0, the swapped score should be 1.0.
     # If a score is not consistent, set it to None, and merge the two
     # explanations to show the inconsistency.
     scores = original_scores.copy()
@@ -104,7 +115,12 @@ def enforce_pairwise_comparison_consistency(
             scores[i] = None
             explanations[i] = None
             continue
-        if scores[i] + swapped_scores[i] != 1.0:  # type: ignore
+
+        if (
+            sorted_available_scores.index(scores[i])  # type: ignore
+            + sorted_available_scores.index(swapped_scores[i])  # type: ignore
+            != len(sorted_available_scores) - 1
+        ):
             scores[i] = None
             explanations[i] = (
                 f"Original assessment: {explanations[i]}\nSwapped assessment: {swapped_explanations[i]}"

--- a/src/langcheck/metrics/_pairwise_text_quality_utils.py
+++ b/src/langcheck/metrics/_pairwise_text_quality_utils.py
@@ -99,11 +99,7 @@ def enforce_pairwise_comparison_consistency(
     sorted_available_scores = list(score_map.values())
     sorted_available_scores.sort()
 
-    # Iterate through the scores and explanations to check for consistency. A
-    # score is consistent if the score's index in the sorted_available_scores
-    # list is the inverse of the swapped score's index. For example, if the
-    # score_map is {'Response A': 0.0, 'Response B': 1.0, 'Tie': 0.5}, and the
-    # score is 0.0, the swapped score should be 1.0.
+    # Iterate through the scores and explanations to check for consistency.
     # If a score is not consistent, set it to None, and merge the two
     # explanations to show the inconsistency.
     scores = original_scores.copy()
@@ -116,6 +112,11 @@ def enforce_pairwise_comparison_consistency(
             explanations[i] = None
             continue
 
+        # A score is consistent if the score's index in the
+        # sorted_available_scores list is the inverse of the swapped score's
+        # index. For example, if the score_map is
+        # {'Response A': 0.0, 'Response B': 1.0, 'Tie': 0.5}, and the score is
+        # 0.0, the swapped score should be 1.0.
         if (
             sorted_available_scores.index(scores[i])  # type: ignore
             + sorted_available_scores.index(swapped_scores[i])  # type: ignore

--- a/src/langcheck/metrics/_validation.py
+++ b/src/langcheck/metrics/_validation.py
@@ -279,6 +279,88 @@ def validate_parameters_custom_evaluator(
     return generated_outputs, prompts, reference_outputs, sources
 
 
+def validate_parameters_custom_pairwise_evaluator(
+    generated_outputs_a: Optional[List[str] | str],
+    generated_outputs_b: Optional[List[str] | str],
+    prompts: Optional[List[str] | str],
+    sources_a: Optional[List[str] | str],
+    sources_b: Optional[List[str] | str],
+    reference_outputs: Optional[List[str] | str],
+) -> tuple[
+    Optional[List[str]],
+    Optional[List[str]],
+    Optional[List[str]],
+    Optional[List[str]],
+    Optional[List[str]],
+    Optional[List[str]],
+]:
+    """Validates and parses function parameters for the custom pairwise
+    evaluator metric.
+
+    Args:
+        generated_outputs_a: The model A generated output(s)
+        generated_outputs_b: The model B generated output(s)
+        prompts: The prompts used to generate the output(s)
+        sources_a: The source(s) of the generated output(s) from model A
+        sources_b: The source(s) of the generated output(s) from model B
+        reference_outputs: The reference output(s)
+
+    Returns:
+        A tuple (generated_outputs_a, generated_outputs_b, prompts, sources_a,
+        sources_b, reference_outputs) of the parsed parameters. All non-None
+        parameters are converted to lists of strings.
+    """
+    # Convert single-string parameters to lists
+    if isinstance(generated_outputs_a, str):
+        generated_outputs_a = [generated_outputs_a]
+    if isinstance(generated_outputs_b, str):
+        generated_outputs_b = [generated_outputs_b]
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    if isinstance(sources_a, str):
+        sources_a = [sources_a]
+    if isinstance(sources_b, str):
+        sources_b = [sources_b]
+    if isinstance(reference_outputs, str):
+        reference_outputs = [reference_outputs]
+
+    # Check that all of the non-None parameters are the same length
+    non_none_lengths = {
+        name: len(arg)
+        for name, arg in zip(
+            [
+                "generated outputs a",
+                "generated outputs b",
+                "prompts",
+                "reference outputs",
+                "sources a",
+                "sources b",
+            ],
+            [
+                generated_outputs_a,
+                generated_outputs_b,
+                prompts,
+                reference_outputs,
+                sources_a,
+                sources_b,
+            ],
+        )
+        if arg is not None
+    }
+    if len(set(non_none_lengths.values())) > 1:
+        raise ValueError(
+            f'The number of {", ".join(non_none_lengths.keys())} do not match'
+        )
+    return (
+        generated_outputs_a,
+        generated_outputs_b,
+        prompts,
+        sources_a,
+        sources_b,
+        reference_outputs,
+    )
+
+
 def _validate_parameters(
     generated_outputs: List[str] | str,
     prompts: Optional[List[str] | str],

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 from jinja2 import Environment, Template, meta
 
-from langcheck.metrics._validation import validate_parameters_custom_evaluator
+from langcheck.metrics._validation import (
+    validate_parameters_custom_evaluator,
+    validate_parameters_custom_pairwise_evaluator,
+)
 from langcheck.metrics.eval_clients import EvalClient
 from langcheck.metrics.metric_value import MetricValue
 
@@ -144,6 +147,192 @@ def custom_evaluator(
         generated_outputs=generated_outputs,
         reference_outputs=reference_outputs,
         sources=sources,
+        explanations=explanations,
+        metric_values=scores,
+        language=language,
+    )
+
+
+def custom_pairwise_evaluator(
+    generated_outputs_a: list[str] | str | None,
+    generated_outputs_b: list[str] | str | None,
+    prompts: list[str] | str | None,
+    sources_a: list[str] | str | None,
+    sources_b: list[str] | str | None,
+    reference_outputs: list[str] | str | None,
+    eval_model: EvalClient,
+    metric_name: str,
+    score_map: dict[str, float],
+    template_path: str,
+    language: str,
+    enforce_consistency: bool = True,
+) -> MetricValue[float | None]:
+    """Calculates the scores of a custom evaluator. The EvalClient will first
+    assess the provided inputs using the prompt template, and then convert those
+    assessments into scores using the score map.
+
+    The prompt template should be a Jinja2 file (file extension .j2) that
+    specifies the criteria that an LLM (as configured in the Eval Client) should
+    follow when evaluating an instance. The template is allowed to have
+    placeholders for the following variables (NOTE: not all are required):
+    - `gen_output`: The generated output
+    - `user_query`: The prompt
+    - `src`: The source text
+    - `ref_output`: The reference output
+
+    The prompt template should also specify the final available assessments for
+    the LLM evaluator, e.g. "Good", "Bad", "Neutral", etc. The score map should
+    then map each of those available assessments to a numerical score. E.g. if
+    the available assessments in the prompt template are "Good", "Bad", and
+    "Neutral", the score map should be something like:
+    ``score_map = {'Good': 1.0, 'Neutral': 0.5, 'Bad': 0.0}``
+
+    NOTE: We have found that LLM models sometimes behave weirdly when the
+    assessments are non-ascii characters (see
+    https://github.com/citadel-ai/langcheck/pull/84 as an example). So, we
+    recommend making the final assessments ascii characters, even when the rest
+    of the prompt template contains non-ascii characters (e.g. Japanese).
+
+    Args:
+        generated_outputs: The model generated output(s)
+        prompts: The prompts used to generate the output(s)
+        sources: The source(s) of the generated output(s)
+        reference_outputs: The reference output(s)
+        eval_model: The EvalClient instance used for the evaluation
+        metric_name: The name of the metric
+        score_map: A dictionary mapping the evaluator's assessments to scores
+        template_path: The path to the prompt template file. This should be a
+            Jinja2 file (file extension .j2).
+        language: The language that the evaluator will use ('en', 'ja', or 'de')
+
+    Returns:
+        A MetricValue object
+    """
+    (
+        generated_outputs_a,
+        generated_outputs_b,
+        prompts,
+        sources_a,
+        sources_b,
+        reference_outputs,
+    ) = validate_parameters_custom_pairwise_evaluator(
+        generated_outputs_a,
+        generated_outputs_b,
+        prompts,
+        sources_a,
+        sources_b,
+        reference_outputs,
+    )
+    # Find the length of the first non-None list (they are guaranteed to all be
+    # the same length)
+    num_examples = next(
+        (
+            len(lst)
+            for lst in [
+                generated_outputs_a,
+                generated_outputs_b,
+                prompts,
+                sources_a,
+                sources_b,
+                reference_outputs,
+            ]
+            if lst is not None
+        ),
+        0,
+    )
+
+    if language not in ["en", "ja", "de"]:
+        raise ValueError(f"Unsupported language: {language}")
+
+    assert Path(
+        template_path
+    ).exists(), f"Prompt template file {template_path} does not exist."
+    assert template_path.endswith(
+        ".j2"
+    ), 'The prompt template file must be a Jinja2 template file with the extension ".j2"'
+
+    prompt_template_source = Path(template_path).read_text()
+    prompt_template = Template(prompt_template_source)
+
+    # Validate the expected parameters in the prompt template
+    env = Environment()
+    expected_params = meta.find_undeclared_variables(
+        env.parse(prompt_template_source)
+    )
+    allowed_params = [
+        "gen_output_a",
+        "gen_output_b",
+        "user_query",
+        "src_a",
+        "src_b",
+        "ref_output",
+    ]
+    assert all(
+        param in allowed_params for param in expected_params
+    ), f"The prompt template contains invalid parameters. The allowed parameters are {allowed_params} but the prompt template expects the parameters {expected_params}"
+    expected_param_to_arg = {
+        "gen_output_a": generated_outputs_a,
+        "gen_output_b": generated_outputs_b,
+        "user_query": prompts,
+        "src_a": sources_a,
+        "src_b": sources_b,
+        "ref_output": reference_outputs,
+    }
+    for param in expected_params:
+        assert (
+            expected_param_to_arg[param] is not None
+        ), f'The prompt template expects the parameter "{param}" but it is not provided.'
+
+    def _args_to_prompt_param(
+        generated_outputs_a,
+        generated_outputs_b,
+        prompts,
+        sources_a,
+        sources_b,
+        reference_outputs,
+        index,
+    ):
+        prompt_param = {}
+        if generated_outputs_a is not None:
+            prompt_param["gen_output_a"] = generated_outputs_a[index]
+        if generated_outputs_b is not None:
+            prompt_param["gen_output_b"] = generated_outputs_b[index]
+        if prompts is not None:
+            prompt_param["user_query"] = prompts[index]
+        if sources_a is not None:
+            prompt_param["src_a"] = sources_a[index]
+        if sources_b is not None:
+            prompt_param["src_b"] = sources_b[index]
+        if reference_outputs is not None:
+            prompt_param["ref_output"] = reference_outputs[index]
+        return prompt_param
+
+    populated_prompts = []
+    for i in range(num_examples):
+        prompt_param = _args_to_prompt_param(
+            generated_outputs_a,
+            generated_outputs_b,
+            prompts,
+            sources_a,
+            sources_b,
+            reference_outputs,
+            i,
+        )
+        populated_prompts.append(prompt_template.render(prompt_param))
+
+    scores, explanations = eval_model.get_score(
+        metric_name=metric_name,
+        language=language,
+        prompts=populated_prompts,
+        score_map=score_map,
+    )
+
+    return MetricValue(
+        metric_name=metric_name,
+        prompts=prompts,
+        generated_outputs=(generated_outputs_a, generated_outputs_b),
+        reference_outputs=reference_outputs,
+        sources=(sources_a, sources_b),
         explanations=explanations,
         metric_values=scores,
         language=language,

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -195,6 +195,10 @@ def custom_pairwise_evaluator(
     like:
     ``score_map = {'Response A': 0.0, 'Response B': 1.0, 'Tie': 0.5}``
 
+    NOTE: If `enforce_consistency` is True, please make sure that the score map
+    is symmetric, in the sense that swapping Model A and Model B should result
+    in inverse scores. See the code below for more details.
+
     NOTE: We have found that LLM models sometimes behave weirdly when the
     assessments are non-ascii characters (see
     https://github.com/citadel-ai/langcheck/pull/84 as an example). So, we

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -167,25 +167,30 @@ def custom_pairwise_evaluator(
     language: str,
     enforce_consistency: bool = True,
 ) -> MetricValue[float | None]:
-    """Calculates the scores of a custom evaluator. The EvalClient will first
-    assess the provided inputs using the prompt template, and then convert those
-    assessments into scores using the score map.
+    """Calculates the scores of a custom pairwise evaluator, where "pairwise"
+    means that the Responses and/or Sources of two systems will be compared
+    against each other. The EvalClient will first assess the provided inputs
+    using the prompt template, and then convert those assessments into scores
+    using the score map.
 
     The prompt template should be a Jinja2 file (file extension .j2) that
     specifies the criteria that an LLM (as configured in the Eval Client) should
     follow when evaluating an instance. The template is allowed to have
     placeholders for the following variables (NOTE: not all are required):
-    - `gen_output`: The generated output
+    - `gen_output_a`: Model A's generated output
+    - `gen_output_b`: Model B's generated output
     - `user_query`: The prompt
-    - `src`: The source text
+    - `src_a`: The source text for Model A
+    - `src_b`: The source text for Model B
     - `ref_output`: The reference output
 
     The prompt template should also specify the final available assessments for
-    the LLM evaluator, e.g. "Good", "Bad", "Neutral", etc. The score map should
-    then map each of those available assessments to a numerical score. E.g. if
-    the available assessments in the prompt template are "Good", "Bad", and
-    "Neutral", the score map should be something like:
-    ``score_map = {'Good': 1.0, 'Neutral': 0.5, 'Bad': 0.0}``
+    the LLM evaluator, e.g. "Response A", "Response B", "Tie", etc. The score
+    map should then map each of those available assessments to a numerical
+    score. E.g. if the available assessments in the prompt template are
+    "Response A", "Response B", and "Tie", the score map should be something
+    like:
+    ``score_map = {'Response A': 0.0, 'Response B': 1.0, 'Tie': 0.5}``
 
     NOTE: We have found that LLM models sometimes behave weirdly when the
     assessments are non-ascii characters (see
@@ -194,9 +199,11 @@ def custom_pairwise_evaluator(
     of the prompt template contains non-ascii characters (e.g. Japanese).
 
     Args:
-        generated_outputs: The model generated output(s)
+        generated_outputs_a: Model A's generated output(s)
+        generated_outputs_b: Model B's generated output(s)
         prompts: The prompts used to generate the output(s)
-        sources: The source(s) of the generated output(s)
+        sources_a: The source(s) for Model A's generated output(s)
+        sources_b: The source(s) for Model B's generated output(s)
         reference_outputs: The reference output(s)
         eval_model: The EvalClient instance used for the evaluation
         metric_name: The name of the metric

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -369,6 +369,26 @@ def custom_pairwise_evaluator(
             score_tqdm_description=score_tqdm,
         )
 
+        # NOTE: The enforce_pairwise_comparison_consistency function assumes
+        # that the score_map is symmetric, in the sense that swapping Model A
+        # and Model B should result in inverse scores. Most score maps should
+        # naturally satisfy this property, but an example of a score map that
+        # does *not* satisfy this property is:
+        # {
+        #   'Response A is much better': 0,
+        #   'Response A is slightly better': 1,
+        #   'Response B is slightly better': 2
+        # }
+        #
+        # In this case, swapping Model A and Model B will not result in
+        # inverse results. The score map should be modified to be symmetric by
+        # adding the 'Response B is much better' option:
+        # {
+        #   'Response A is much better': 0,
+        #   'Response A is slightly better': 1,
+        #   'Response B is slightly better': 2,
+        #   'Response B is much better': 3
+        # }
         scores, explanations = enforce_pairwise_comparison_consistency(
             scores,
             explanations,

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -214,6 +214,10 @@ def custom_pairwise_evaluator(
         template_path: The path to the prompt template file. This should be a
             Jinja2 file (file extension .j2).
         language: The language that the evaluator will use ('en', 'ja', or 'de')
+        enforce_consistency: When this is True, we will only return a score if
+            the score is the same when Model A and Model B are swapped. This is
+            useful for ensuring that the evaluator's position bias is not
+            impacting the scores. Default True.
 
     Returns:
         A MetricValue object

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -130,7 +130,11 @@ def pairwise_comparison(
         )
 
         scores, explanations = enforce_pairwise_comparison_consistency(
-            scores, explanations, swapped_scores, swapped_explanations
+            scores,
+            explanations,
+            swapped_scores,
+            swapped_explanations,
+            pairwise_comparison_assessment_to_score,
         )
 
     return MetricValue(

--- a/src/langcheck/metrics/ja/pairwise_text_quality.py
+++ b/src/langcheck/metrics/ja/pairwise_text_quality.py
@@ -133,7 +133,11 @@ def pairwise_comparison(
         )
 
         scores, explanations = enforce_pairwise_comparison_consistency(
-            scores, explanations, swapped_scores, swapped_explanations
+            scores,
+            explanations,
+            swapped_scores,
+            swapped_explanations,
+            pairwise_comparison_assessment_to_score,
         )
 
     return MetricValue(

--- a/src/langcheck/metrics/metric_value.py
+++ b/src/langcheck/metrics/metric_value.py
@@ -16,6 +16,7 @@ NumericType = TypeVar("NumericType", float, int, Optional[float], Optional[int])
 @dataclass
 class MetricValue(Generic[NumericType]):
     """A rich object that is the output of any langcheck.metrics function."""
+
     metric_name: str
     metric_values: List[NumericType]
     prompts: Optional[List[str]]
@@ -23,8 +24,9 @@ class MetricValue(Generic[NumericType]):
     generated_outputs: Optional[List[str] | tuple[List[str], List[str]]]
     reference_outputs: Optional[List[str]]
     # Sources are a tuple for pairwise metrics (if available)
-    sources: Optional[List[str] |
-                      tuple[Optional[List[str]], Optional[List[str]]]]
+    sources: Optional[
+        List[str] | tuple[Optional[List[str]], Optional[List[str]]]
+    ]
     # An explanation can be None if the metric could not be computed
     explanations: Optional[List[Optional[str]]]
     language: Optional[str]
@@ -35,8 +37,9 @@ class MetricValue(Generic[NumericType]):
             # For type checking
             assert self.generated_outputs is not None
             generated_outputs_a, generated_outputs_b = self.generated_outputs
-            sources_a, sources_b = self.sources if self.sources else (None,
-                                                                      None)
+            sources_a, sources_b = (
+                self.sources if self.sources else (None, None)
+            )
             dataframe_cols = {
                 "prompt": self.prompts,
                 "source_a": sources_a,
@@ -63,8 +66,7 @@ class MetricValue(Generic[NumericType]):
         """Returns a string representation of an
         :class:`~langcheck.metrics.metric_value.MetricValue` object.
         """
-        return (f"Metric: {self.metric_name}\n"
-                f"{self.to_df()}")
+        return f"Metric: {self.metric_name}\n" f"{self.to_df()}"
 
     def __repr__(self) -> str:
         """Returns a string representation of an
@@ -77,51 +79,51 @@ class MetricValue(Generic[NumericType]):
         :class:`~langcheck.metrics.metric_value.MetricValue`, which is
         automatically called by Jupyter notebooks.
         """
-        return (f"Metric: {self.metric_name}<br>"
-                f"{self.to_df()._repr_html_()}"  # type: ignore
-               )
+        return (
+            f"Metric: {self.metric_name}<br>" f"{self.to_df()._repr_html_()}"  # type: ignore
+        )
 
     def __lt__(self, threshold: float | int) -> MetricValueWithThreshold:
         """Allows the user to write a `metric_value < 0.5` expression."""
         all_fields = {f.name: getattr(self, f.name) for f in fields(self)}
-        return MetricValueWithThreshold(**all_fields,
-                                        threshold=threshold,
-                                        threshold_op="<")
+        return MetricValueWithThreshold(
+            **all_fields, threshold=threshold, threshold_op="<"
+        )
 
     def __le__(self, threshold: float | int) -> MetricValueWithThreshold:
         """Allows the user to write a `metric_value <= 0.5` expression."""
         all_fields = {f.name: getattr(self, f.name) for f in fields(self)}
-        return MetricValueWithThreshold(**all_fields,
-                                        threshold=threshold,
-                                        threshold_op="<=")
+        return MetricValueWithThreshold(
+            **all_fields, threshold=threshold, threshold_op="<="
+        )
 
     def __gt__(self, threshold: float | int) -> MetricValueWithThreshold:
         """Allows the user to write a `metric_value > 0.5` expression."""
         all_fields = {f.name: getattr(self, f.name) for f in fields(self)}
-        return MetricValueWithThreshold(**all_fields,
-                                        threshold=threshold,
-                                        threshold_op=">")
+        return MetricValueWithThreshold(
+            **all_fields, threshold=threshold, threshold_op=">"
+        )
 
     def __ge__(self, threshold: float | int) -> MetricValueWithThreshold:
         """Allows the user to write a `metric_value >= 0.5` expression."""
         all_fields = {f.name: getattr(self, f.name) for f in fields(self)}
-        return MetricValueWithThreshold(**all_fields,
-                                        threshold=threshold,
-                                        threshold_op=">=")
+        return MetricValueWithThreshold(
+            **all_fields, threshold=threshold, threshold_op=">="
+        )
 
     def __eq__(self, threshold: float | int) -> MetricValueWithThreshold:
         """Allows the user to write a `metric_value == 0.5` expression."""
         all_fields = {f.name: getattr(self, f.name) for f in fields(self)}
-        return MetricValueWithThreshold(**all_fields,
-                                        threshold=threshold,
-                                        threshold_op="==")
+        return MetricValueWithThreshold(
+            **all_fields, threshold=threshold, threshold_op="=="
+        )
 
     def __ne__(self, threshold: float | int) -> MetricValueWithThreshold:
         """Allows the user to write a `metric_value != 0.5` expression."""
         all_fields = {f.name: getattr(self, f.name) for f in fields(self)}
-        return MetricValueWithThreshold(**all_fields,
-                                        threshold=threshold,
-                                        threshold_op="!=")
+        return MetricValueWithThreshold(
+            **all_fields, threshold=threshold, threshold_op="!="
+        )
 
     def all(self) -> bool:
         """Equivalent to all(metric_value.metric_values). This is mostly useful
@@ -139,7 +141,8 @@ class MetricValue(Generic[NumericType]):
         raise ValueError(
             "A MetricValue cannot be used as a boolean. "
             "Try an expression like `metric_value > 0.5`, "
-            "`metric_value.all()`, or `metric_value.any()` instead.")
+            "`metric_value.all()`, or `metric_value.any()` instead."
+        )
 
     def scatter(self, jupyter_mode: str = "inline") -> None:
         """Shows an interactive scatter plot of all data points in MetricValue.
@@ -153,7 +156,8 @@ class MetricValue(Generic[NumericType]):
         # Type ignore because a Self type is only valid in class contexts
         return plot_scatter(
             self,  # type: ignore[reportGeneralTypeIssues]
-            jupyter_mode=jupyter_mode)
+            jupyter_mode=jupyter_mode,
+        )
 
     def histogram(self, jupyter_mode: str = "inline") -> None:
         """Shows an interactive histogram of all data points in MetricValue.
@@ -167,7 +171,8 @@ class MetricValue(Generic[NumericType]):
         # Type ignore because a Self type is only valid in class contexts
         return plot_histogram(
             self,  # type: ignore[reportGeneralTypeIssues]
-            jupyter_mode=jupyter_mode)
+            jupyter_mode=jupyter_mode,
+        )
 
     @property
     def is_pairwise(self) -> bool:
@@ -180,6 +185,7 @@ class MetricValueWithThreshold(MetricValue):
     :class:`~langcheck.metrics.metric_value.MetricValue` object,
     e.g. `metric_value >= 0.5`.
     """
+
     threshold: float | int
     threshold_op: str  # One of '<', '<=', '>', '>=', '==', '!='
 
@@ -193,7 +199,7 @@ class MetricValueWithThreshold(MetricValue):
             ">": operator.gt,
             ">=": operator.ge,
             "==": operator.eq,
-            "!=": operator.ne
+            "!=": operator.ne,
         }
 
         if self.threshold_op not in operators:
@@ -205,12 +211,15 @@ class MetricValueWithThreshold(MetricValue):
         if None in self.metric_values:
             warnings.warn(
                 "The threshold result for `None` values in `metric_values` will"
-                " always be `False`.")
+                " always be `False`."
+            )
 
         # Set the result to `False` if the metric value is `None`
         self._threshold_results = [
             operators[self.threshold_op](x, self.threshold)
-            if x is not None else False for x in self.metric_values
+            if x is not None
+            else False
+            for x in self.metric_values
         ]
 
         self._pass_rate = mean(self._threshold_results)
@@ -242,9 +251,11 @@ class MetricValueWithThreshold(MetricValue):
         """Returns a string representation of an
         :class:`~langcheck.metrics.metric_value.MetricValue`.
         """
-        return (f"Metric: {self.metric_name}\n"
-                f"Pass Rate: {round(self.pass_rate*100, 2)}%\n"
-                f"{self.to_df()}")
+        return (
+            f"Metric: {self.metric_name}\n"
+            f"Pass Rate: {round(self.pass_rate*100, 2)}%\n"
+            f"{self.to_df()}"
+        )
 
     def __repr__(self) -> str:
         """Returns a string representation of an
@@ -257,10 +268,11 @@ class MetricValueWithThreshold(MetricValue):
         :class:`~langcheck.metrics.metric_value.MetricValue`, which is
         automatically called by Jupyter notebooks.
         """
-        return (f"Metric: {self.metric_name}<br>"
-                f"Pass Rate: {round(self.pass_rate*100, 2)}%<br>"
-                f"{self.to_df()._repr_html_()}"  # type: ignore
-               )
+        return (
+            f"Metric: {self.metric_name}<br>"
+            f"Pass Rate: {round(self.pass_rate*100, 2)}%<br>"
+            f"{self.to_df()._repr_html_()}"  # type: ignore
+        )
 
     def all(self) -> bool:
         """Returns True if all data points pass the threshold."""

--- a/src/langcheck/metrics/metric_value.py
+++ b/src/langcheck/metrics/metric_value.py
@@ -21,7 +21,9 @@ class MetricValue(Generic[NumericType]):
     metric_values: List[NumericType]
     prompts: Optional[List[str]]
     # Generated outputs are a tuple for pairwise metrics
-    generated_outputs: Optional[List[str] | tuple[List[str], List[str]]]
+    generated_outputs: Optional[
+        List[str] | tuple[Optional[List[str]], Optional[List[str]]]
+    ]
     reference_outputs: Optional[List[str]]
     # Sources are a tuple for pairwise metrics (if available)
     sources: Optional[

--- a/tests/metrics/test_custom_text_quality.py
+++ b/tests/metrics/test_custom_text_quality.py
@@ -1,7 +1,7 @@
 import tempfile
 
 import pytest
-from langcheck.metrics import custom_evaluator
+from langcheck.metrics import custom_evaluator, custom_pairwise_evaluator
 
 from tests.utils import MockEvalClient
 
@@ -12,15 +12,20 @@ from tests.utils import MockEvalClient
 
 @pytest.mark.parametrize(
     "generated_outputs,sources",
-    [("Tokyo is the capital of Japan.", "Tokyo is Japan's capital city."),
-     (["Tokyo is the capital of Japan.", "The Earth is flat."
-      ], ["Tokyo is Japan's capital city.", "The Earth is round."])])
+    [
+        ("Tokyo is the capital of Japan.", "Tokyo is Japan's capital city."),
+        (
+            ["Tokyo is the capital of Japan.", "The Earth is flat."],
+            ["Tokyo is Japan's capital city.", "The Earth is round."],
+        ),
+    ],
+)
 def test_custom_evaluator(generated_outputs, sources):
     metric_name = "factual consistency"
     score_map = {
         "Fully Consistent": 1.0,
         "Partially Consistent": 0.5,
-        "Not Consistent": 0.0
+        "Not Consistent": 0.0,
     }
     # Create a temporary Jinja2 template file
     with tempfile.NamedTemporaryFile(suffix=".j2") as temp:
@@ -33,7 +38,117 @@ def test_custom_evaluator(generated_outputs, sources):
 
         for option in score_map:
             eval_client = MockEvalClient(option)
-            metric_value = custom_evaluator(generated_outputs, None, sources,
-                                            None, eval_client, metric_name,
-                                            score_map, template_path, "en")
+            metric_value = custom_evaluator(
+                generated_outputs,
+                None,
+                sources,
+                None,
+                eval_client,
+                metric_name,
+                score_map,
+                template_path,
+                "en",
+            )
             assert metric_value == score_map[option]
+
+
+@pytest.mark.parametrize(
+    "generated_outputs_a,generated_outputs_b,prompts,sources_a,sources_b,reference_outputs",
+    [
+        (
+            "Tokyo is Japan's capital city.",
+            "New York is Japan's capital city.",
+            "What is the capital of Japan?",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Tokyo is Japan's capital city.",
+            "New York is Japan's capital city.",
+            "What is the capital of Japan?",
+            None,
+            None,
+            "Tokyo",
+        ),
+        (
+            "Tokyo is Japan's capital city.",
+            "New York is Japan's capital city.",
+            "What is the capital of Japan?",
+            "Capital of Japan = Tokyo",
+            None,
+            None,
+        ),
+        (
+            "Tokyo is Japan's capital city.",
+            "New York is Japan's capital city.",
+            "What is the capital of Japan?",
+            "Capital of Japan = Tokyo",
+            "Capital of Japan = Tokyo",
+            None,
+        ),
+        (
+            "Tokyo is Japan's capital city.",
+            "New York is Japan's capital city.",
+            "What is the capital of Japan?",
+            "Capital of Japan = Tokyo",
+            "Capital of Japan = Tokyo",
+            "Tokyo",
+        ),
+    ],
+)
+def test_custom_pairwise_evaluator(
+    generated_outputs_a,
+    generated_outputs_b,
+    prompts,
+    sources_a,
+    sources_b,
+    reference_outputs,
+):
+    """Test the custom pairwise evaluator.
+
+    Test 1: No sources or reference outputs are provided.
+    Test 2: Reference output is provided.
+    Test 3: Source A is provided.
+    Test 4: Both Source A and Source B are provided.
+    Test 5: Source A, Source B, and the reference output are provided.
+    """
+    metric_name = "pairwise factual correctness"
+    score_map = {"Response B": 1.0, "Tie": 0.5, "Response A": 0.0}
+    # Create a temporary Jinja2 template file
+    with tempfile.NamedTemporaryFile(suffix=".j2") as temp:
+        temp.write(b"""
+        Determine which of the two responses is more factually correct:
+        [User Query]: {{ user_query }}
+        {% if src_a is not none %}
+        [Source A]: {{ src_a }}
+        {% endif %}
+        {% if src_b is not none %}
+        [Source B]: {{ src_b }}
+        {% endif %}
+        {% if ref_output is not none %}
+        [Ideal Response]: {{ ref_output }}
+        {% endif %}
+        [Response A]: {{ gen_output_a }}
+        [Response B]: {{ gen_output_b }}
+        """)
+        template_path = temp.name
+
+        # Return "Tie" so that it passes the consistency check
+        eval_client = MockEvalClient("Tie")
+        metric_value = custom_pairwise_evaluator(
+            generated_outputs_a,
+            generated_outputs_b,
+            prompts,
+            sources_a,
+            sources_b,
+            reference_outputs,
+            eval_client,
+            metric_name,
+            score_map,
+            template_path,
+            "en",
+        )
+
+        # MockEvalClient returns 0.5 for Tie
+        assert metric_value == 0.5


### PR DESCRIPTION
Adds a `custom_pairwise_evaluator` metric that allows users to specify a custom prompt-based pairwise metric. Similar to the pairwise comparison metric, `enforce_consistency` is enabled by default.

Some examples of metrics that you can create with this are:
- Pairwise answer correctness - which response (A or B) is more correct / closer to the reference answer?
- Pairwise toxicity - which response (A or B) is less toxic?
- Pairwise context relevance - which source text (A or B) is more relevant for answering the user's query?

E.g. you can create your own "Pairwise Answer Conciseness" metric with a prompt template like:
```
You are evaluating the conciseness of the answer to a user's query. Here is the data:
[BEGIN DATA]
************
[User Query]: {{ user_query }}
************
[Answer A]: {{ gen_output_a }}
************
[Answer B]: {{ gen_output_b }}
************
[END DATA]

Determine which of the responses is a more concise response to the user's query.
The available assessments are:
`Response A` - Response A is a more concise response.
`Response B` - Response B is a more concise response.
`Tie` - The two responses are roughly equal in conciseness.

Write out a one-sentence justification before giving the final assessment.
```

And then compute the metric like this:
```
# Create an eval_client as usual

gen_output_a = [
    "4",
    "The answer to the question 2+2 is 4. If you need any more assistance with math, feel free to ask!",
    "I cannot answer that question."
]
gen_output_b = [
    "The answer to the question 2+2 is 4. If you need any more assistance with math, feel free to ask!",
    "4",
    "I don't know the answer to that question."
]
prompt = ["what is 2+2?", "what is 2+2?", "what is 2+2?"]
score_map = {"Response A": 0.0, "Response B": 1.0, "Tie": 0.5}

langcheck.metrics.custom_pairwise_evaluator(
    generated_outputs_a=gen_output_a,
    generated_outputs_b=gen_output_b,
    prompts=prompt,
    sources_a=None,
    sources_b=None,
    reference_outputs=None,
    eval_model=eval_client,
    metric_name="answer_conciseness",
    score_map=score_map,
    template_path="pairwise_answer_conciseness.j2",
    language="en",
)
```
<img width="1619" alt="image" src="https://github.com/citadel-ai/langcheck/assets/107823399/1c1ecc97-f144-46ac-9820-9866daa97b5d">
