### PR TITLE
Fix text encoding

### DIFF
--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -93,7 +93,7 @@ def custom_evaluator(
         ".j2"
     ), 'The prompt template file must be a Jinja2 template file with the extension ".j2"'
 
-    prompt_template_source = Path(template_path).read_text()
+    prompt_template_source = Path(template_path).read_text(encoding="utf-8")
     prompt_template = Template(prompt_template_source)
 
     # Validate the expected parameters in the prompt template
@@ -269,7 +269,7 @@ def custom_pairwise_evaluator(
         ".j2"
     ), 'The prompt template file must be a Jinja2 template file with the extension ".j2"'
 
-    prompt_template_source = Path(template_path).read_text()
+    prompt_template_source = Path(template_path).read_text(encoding="utf-8")
     prompt_template = Template(prompt_template_source)
 
     # Validate the expected parameters in the prompt template

--- a/src/langcheck/metrics/prompts/_utils.py
+++ b/src/langcheck/metrics/prompts/_utils.py
@@ -14,4 +14,4 @@ def get_template(relative_path: str) -> Template:
         Template: The Jinja template.
     """
     cwd = Path(__file__).parent
-    return Template((cwd / relative_path).read_text())
+    return Template((cwd / relative_path).read_text(encoding="utf-8"))


### PR DESCRIPTION
In some Python 3.10 environments, `io.text_encoding` will return `"locale"` encoding by default, which can not decode certain Japanese characters. Set the encoding mode to `utf-8` solves the problem.