### PR TITLE
Update docs to reflect new metric structure

### DIFF
--- a/docs/langcheck.metrics.custom_text_quality.rst
+++ b/docs/langcheck.metrics.custom_text_quality.rst
@@ -1,0 +1,8 @@
+
+langcheck.metrics.custom\_text\_quality
+=======================================
+
+.. automodule:: langcheck.metrics.custom_text_quality
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.de.query_based_text_quality.rst
+++ b/docs/langcheck.metrics.de.query_based_text_quality.rst
@@ -1,0 +1,8 @@
+
+langcheck.metrics.de.query\_based\_text\_quality
+================================================
+
+.. automodule:: langcheck.metrics.de.query_based_text_quality
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.de.rst
+++ b/docs/langcheck.metrics.de.rst
@@ -16,6 +16,7 @@ langcheck.metrics.de
    :hidden:
    :maxdepth: 4
 
+   langcheck.metrics.de.query_based_text_quality
    langcheck.metrics.de.reference_based_text_quality
    langcheck.metrics.de.reference_free_text_quality
    langcheck.metrics.de.source_based_text_quality

--- a/docs/langcheck.metrics.en.query_based_text_quality.rst
+++ b/docs/langcheck.metrics.en.query_based_text_quality.rst
@@ -1,0 +1,8 @@
+
+langcheck.metrics.en.query\_based\_text\_quality
+================================================
+
+.. automodule:: langcheck.metrics.en.query_based_text_quality
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.en.rst
+++ b/docs/langcheck.metrics.en.rst
@@ -27,6 +27,7 @@ langcheck.metrics.en
    :maxdepth: 4
 
    langcheck.metrics.en.pairwise_text_quality
+   langcheck.metrics.en.query_based_text_quality
    langcheck.metrics.en.reference_based_text_quality
    langcheck.metrics.en.reference_free_text_quality
    langcheck.metrics.en.source_based_text_quality

--- a/docs/langcheck.metrics.ja.query_based_text_quality.rst
+++ b/docs/langcheck.metrics.ja.query_based_text_quality.rst
@@ -1,0 +1,8 @@
+
+langcheck.metrics.ja.query\_based\_text\_quality
+================================================
+
+.. automodule:: langcheck.metrics.ja.query_based_text_quality
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.ja.rst
+++ b/docs/langcheck.metrics.ja.rst
@@ -17,6 +17,7 @@ langcheck.metrics.ja
    :maxdepth: 4
 
    langcheck.metrics.ja.pairwise_text_quality
+   langcheck.metrics.ja.query_based_text_quality
    langcheck.metrics.ja.reference_based_text_quality
    langcheck.metrics.ja.reference_free_text_quality
    langcheck.metrics.ja.source_based_text_quality

--- a/docs/langcheck.metrics.rst
+++ b/docs/langcheck.metrics.rst
@@ -67,6 +67,7 @@ There are several different types of metrics:
    :hidden:
    :maxdepth: 4
 
+   langcheck.metrics.custom_text_quality
    langcheck.metrics.metric_value
    langcheck.metrics.reference_based_text_quality
    langcheck.metrics.text_structure


### PR DESCRIPTION
https://github.com/citadel-ai/langcheck/pull/138 changed the structure a bit so the docs need to be updated.

Followed https://github.com/citadel-ai/langcheck/blob/main/docs/contributing.md#documentation and ran:
```
sphinx-apidoc -f --no-toc --separate --module-first -t docs/_templates/ -o docs src/langcheck/ src/langcheck/stats.py src/langcheck/metrics/model_manager

make -C docs clean html
```