### PR TITLE
Add nltk download in langcheck.augment.synonym

### DIFF
--- a/src/langcheck/augment/en/_synonym.py
+++ b/src/langcheck/augment/en/_synonym.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import nltk
 from nlpaug.augmenter.word import SynonymAug
 
 
@@ -40,6 +41,11 @@ def synonym(
 
     kwargs["aug_p"] = kwargs.get("aug_p", 0.1)
     kwargs["aug_max"] = kwargs.get("aug_max")
+
+    try:
+        nltk.data.find("averaged_perceptron_tagger_eng")
+    except LookupError:
+        nltk.download("averaged_perceptron_tagger_eng")
 
     instances = [instances] if isinstance(instances, str) else instances
     perturbed_instances = []

--- a/src/langcheck/augment/en/_synonym.py
+++ b/src/langcheck/augment/en/_synonym.py
@@ -43,7 +43,7 @@ def synonym(
     kwargs["aug_max"] = kwargs.get("aug_max")
 
     try:
-        nltk.data.find("averaged_perceptron_tagger_eng")
+        nltk.data.find("taggers/averaged_perceptron_tagger_eng")
     except LookupError:
         nltk.download("averaged_perceptron_tagger_eng")
 


### PR DESCRIPTION
Resolves #153 

```
In [2]: langcheck.augment.synonym('aaaa')
[nltk_data] Downloading package averaged_perceptron_tagger_eng to
[nltk_data]     /Users/taniokay/nltk_data...
[nltk_data]   Unzipping taggers/averaged_perceptron_tagger_eng.zip.
Out[2]: ['aaaa']
```