### PR TITLE
Add no-local-llm to avoid vllm installation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// PyTorch 2.1.0 causes segmentation fault in aarch64, so we pin the version in the dev container until the bug is fixed.
 	// Ref: https://github.com/pytorch/pytorch/issues/110819
-	"postCreateCommand": "curl https://sh.rustup.rs -sSf | bash -s -- -y && . $HOME/.cargo/env && pip install --upgrade pip && pip install yapf==0.40.1 && python -m pip install -e .[all,dev]",
+	"postCreateCommand": "curl https://sh.rustup.rs -sSf | bash -s -- -y && . $HOME/.cargo/env && pip install --upgrade pip && pip install yapf==0.40.1 && python -m pip install -e .[no-local-llm,dev]",
 	"customizations": {
 		// Configure properties specific to VS Code.
 		"vscode": {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,14 +71,19 @@ If you do not need the `[ja-optional]` dependencies, you can also install each l
 pip install langcheck[en,ja,de,zh]
 ```
 
+### 4. The error message `Failed to build vllm`
 
-### 4. The error `AttributeError: module 'langcheck.metrics' has no attribute 'ja'`
+The `vllm` package, which is installed with `langcheck[all]`, does not have a pre-built wheel for ARM devices, so ARM users would see the errors while building `vllm`.
+
+You should try `pip install langcheck[no-local-llm]`, that will install all the dependencies other than `vllm`.
+
+### 5. The error `AttributeError: module 'langcheck.metrics' has no attribute 'ja'`
 
 If you see this error when calling a LangCheck function, such as `langcheck.metrics.ja.toxicity()`, you probably need to install the Japanese LangCheck package.
 
 Run `pip install langcheck[ja]` (or for your required language) and try again.
 
-### 5. The error `ModuleNotFoundError`
+### 6. The error `ModuleNotFoundError`
 
 If you see this error when importing a LangCheck package, such as `import langcheck.metrics.ja`, you probably need to install the Japanese LangCheck package.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,16 @@ all = [
     'langcheck[local-llm]'
 ]
 
+no-local-llm = [
+    'langcheck[de]',
+    'langcheck[en]',
+    'langcheck[ja]',
+    'langcheck[ja-optional]',
+    'langcheck[zh]',
+    'langcheck[anthropic]',
+    'langcheck[gemini]',
+]
+
 dev = [
     "ruff >= 0.6",
     "pyright",


### PR DESCRIPTION
`vllm` installation fails in building devcontainer on ARM architecture like below.
As an alternative, this PR adds another dependency group `no-local-llm` that excludes `local-llm` from `all`, and makes it default in devcontainer building.
```
Collecting vllm (from langcheck==0.8.0.dev6)
  Downloading vllm-0.6.1.post2.tar.gz (1.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB 10.9 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [21 lines of output]
      /tmp/pip-build-env-_xaa7ek5/overlay/lib/python3.9/site-packages/torch/_subclasses/functional_tensor.py:258: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
        cpu = _conversion_method_template(device=torch.device("cpu"))
      fatal: not a git repository (or any of the parent directories): .git
      <string>:56: RuntimeWarning: Failed to get commit hash:
      Command '['git', 'rev-parse', 'HEAD']' returned non-zero exit status 128.
      Traceback (most recent call last):
        File "/home/vscode/.local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/vscode/.local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/vscode/.local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-_xaa7ek5/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-_xaa7ek5/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-_xaa7ek5/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 480, in <module>
        File "<string>", line 396, in get_vllm_version
      RuntimeError: Unknown runtime environment
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```