### PR TITLE
Support Async API for embedding based metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     'Jinja2',
     'nlpaug',
     'nltk >= 3.9',
-    'openai >= 1',
+    'openai >= 1, < 1.47',
     'pandas >= 1',
     'plotly >= 5',
     'rouge-score >= 0.1.2',

--- a/src/langcheck/metrics/eval_clients/_base.py
+++ b/src/langcheck/metrics/eval_clients/_base.py
@@ -49,7 +49,7 @@ class EvalClient:
     def get_text_responses(
         self, prompts: Iterable[str], *, tqdm_description: str | None = None
     ) -> list[str | None]:
-        """The function that gets resonses to the given prompt texts. Each
+        """The function that gets responses to the given prompt texts. Each
         concrete subclass needs to define the concrete implementation of this
         function to enable text scoring.
 

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -428,6 +428,8 @@ class OpenAISimilarityScorer(BaseSimilarityScorer):
     def _embed(self, inputs: list[str]) -> torch.Tensor:
         """Embed the inputs using the OpenAI API."""
 
+        # TODO: Fix that this async call could be much slower than the sync
+        # version. https://github.com/citadel-ai/langcheck/issues/160
         if self._use_async:
             async def _call_async_api() -> Any:
                 assert isinstance(self.openai_client, AsyncOpenAI)

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -429,16 +429,14 @@ class OpenAISimilarityScorer(BaseSimilarityScorer):
         """Embed the inputs using the OpenAI API."""
 
         if self._use_async:
-            assert isinstance(self.openai_client, AsyncOpenAI)
-
             async def _call_async_api() -> Any:
-                # Ignoring the type because the return value is not Future.
+                assert isinstance(self.openai_client, AsyncOpenAI)
                 if self.openai_args:
-                    responses = await self.openai_client.embeddings.create(  # type: ignore
+                    responses = await self.openai_client.embeddings.create(
                         input=inputs, **self.openai_args
                     )
                 else:
-                    responses = await self.openai_client.embeddings.create(  # type: ignore
+                    responses = await self.openai_client.embeddings.create(
                         input=inputs, model="text-embedding-3-small"
                     )
                 return responses

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -301,11 +301,10 @@ class OpenAIEvalClient(EvalClient):
         """
         https://openai.com/blog/new-embedding-models-and-api-updates
         """
-        assert isinstance(
-            self._client, OpenAI
-        ), "Only sync clients are supported for similarity scoring."
         return OpenAISimilarityScorer(
-            openai_client=self._client, openai_args=self._openai_args
+            openai_client=self._client,
+            openai_args=self._openai_args,
+            use_async=self._use_async,
         )
 
 
@@ -396,16 +395,15 @@ class AzureOpenAIEvalClient(OpenAIEvalClient):
         additional "model" parameter. See the parent class for the detailed
         documentation.
         """
-        assert isinstance(
-            self._client, AzureOpenAI
-        ), "Only sync clients are supported for similarity scoring."
         assert self._embedding_model_name is not None, (
             "You need to specify the embedding_model_name to get the score for "
             "this metric."
         )
         openai_args = {**self._openai_args, "model": self._embedding_model_name}
         return OpenAISimilarityScorer(
-            openai_client=self._client, openai_args=openai_args
+            openai_client=self._client,
+            openai_args=openai_args,
+            use_async=self._use_async,
         )
 
 
@@ -417,24 +415,51 @@ class OpenAISimilarityScorer(BaseSimilarityScorer):
 
     def __init__(
         self,
-        openai_client: OpenAI | AzureOpenAI,
+        openai_client: OpenAI | AzureOpenAI | AsyncOpenAI | AsyncAzureOpenAI,
         openai_args: dict[str, Any] | None = None,
+        use_async: bool = False,
     ):
         super().__init__()
 
         self.openai_client = openai_client
         self.openai_args = openai_args
+        self._use_async = use_async
 
     def _embed(self, inputs: list[str]) -> torch.Tensor:
         """Embed the inputs using the OpenAI API."""
-        # Embed the inputs
-        if self.openai_args:
-            embed_response = self.openai_client.embeddings.create(
-                input=inputs, **self.openai_args
-            )
-        else:
-            embed_response = self.openai_client.embeddings.create(
-                input=inputs, model="text-embedding-3-small"
+
+        if self._use_async:
+            assert isinstance(self.openai_client, AsyncOpenAI) or isinstance(
+                self.openai_client, AsyncAzureOpenAI
             )
 
-        return torch.Tensor([item.embedding for item in embed_response.data])
+            async def _call_async_api() -> Any:
+                if self.openai_args:
+                    responses = await self.openai_client.embeddings.create(
+                        input=inputs, **self.openai_args
+                    )
+                else:
+                    responses = await self.openai_client.embeddings.create(
+                        input=inputs, model="text-embedding-3-small"
+                    )
+                return responses
+
+            embed_response = asyncio.run(_call_async_api())
+            embeddings = [item.embedding for item in embed_response.data]
+
+        else:
+            assert isinstance(self.openai_client, OpenAI) or isinstance(
+                self.openai_client, AzureOpenAI
+            )
+
+            if self.openai_args:
+                embed_response = self.openai_client.embeddings.create(
+                    input=inputs, **self.openai_args
+                )
+            else:
+                embed_response = self.openai_client.embeddings.create(
+                    input=inputs, model="text-embedding-3-small"
+                )
+            embeddings = [item.embedding for item in embed_response.data]
+
+        return torch.Tensor(embeddings)

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -429,17 +429,16 @@ class OpenAISimilarityScorer(BaseSimilarityScorer):
         """Embed the inputs using the OpenAI API."""
 
         if self._use_async:
-            assert isinstance(self.openai_client, AsyncOpenAI) or isinstance(
-                self.openai_client, AsyncAzureOpenAI
-            )
+            assert isinstance(self.openai_client, AsyncOpenAI)
 
             async def _call_async_api() -> Any:
+                # Ignoring the type because the return value is not Future.
                 if self.openai_args:
-                    responses = await self.openai_client.embeddings.create(
+                    responses = await self.openai_client.embeddings.create(  # type: ignore
                         input=inputs, **self.openai_args
                     )
                 else:
-                    responses = await self.openai_client.embeddings.create(
+                    responses = await self.openai_client.embeddings.create(  # type: ignore
                         input=inputs, model="text-embedding-3-small"
                     )
                 return responses
@@ -448,9 +447,7 @@ class OpenAISimilarityScorer(BaseSimilarityScorer):
             embeddings = [item.embedding for item in embed_response.data]
 
         else:
-            assert isinstance(self.openai_client, OpenAI) or isinstance(
-                self.openai_client, AzureOpenAI
-            )
+            assert isinstance(self.openai_client, OpenAI)
 
             if self.openai_args:
                 embed_response = self.openai_client.embeddings.create(


### PR DESCRIPTION
Resolves #156 

Both eval clients (`AzureOpenAIEvalClient`, `OpenAIEvalClient`) didn't implement async call of embedding function, so this PR adds that async API.

And also, I encountered some connection errors with `openai==1.47.0` so I pinned the version below 1.47. 