### PR TITLE
Add [python] to format setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.organizeImports": "explicit"
-  },
-  "editor.formatOnSaveMode": "file",
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "charliermarsh.ruff"
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    },
+    "editor.formatOnSaveMode": "file",
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  }
 }


### PR DESCRIPTION
Format on save wasn't working correctly in my devcontainer environment, but it's resolved by explicitly specifying the language.
I guess the even original config should work, but let me fix it as this is also how Ruff extension does in its description.