### PR TITLE
Fix issues in docs

### DIFF
--- a/docs/langcheck.metrics.metric_inputs.rst
+++ b/docs/langcheck.metrics.metric_inputs.rst
@@ -1,0 +1,7 @@
+langcheck.metrics.metric\_inputs module
+=======================================
+
+.. automodule:: langcheck.metrics.metric_inputs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/langcheck.metrics.rst
+++ b/docs/langcheck.metrics.rst
@@ -72,6 +72,7 @@ There are several different types of metrics:
    :maxdepth: 4
 
    langcheck.metrics.custom_text_quality
+   langcheck.metrics.metric_inputs
    langcheck.metrics.metric_value
    langcheck.metrics.reference_based_text_quality
    langcheck.metrics.text_structure

--- a/docs/langcheck.utils.progress_bar.rst
+++ b/docs/langcheck.utils.progress_bar.rst
@@ -2,7 +2,7 @@
 langcheck.utils.progess\_bar
 ============================
 
-.. automodule:: langcheck.utils.progess_bar
+.. automodule:: langcheck.utils.progress_bar
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/langcheck.utils.progress_bar.rst
+++ b/docs/langcheck.utils.progress_bar.rst
@@ -1,5 +1,5 @@
 
-langcheck.utils.progess\_bar
+langcheck.utils.progress\_bar
 ============================
 
 .. automodule:: langcheck.utils.progress_bar

--- a/docs/langcheck.utils.rst
+++ b/docs/langcheck.utils.rst
@@ -28,4 +28,4 @@ langcheck.utils
    :maxdepth: 4
 
    langcheck.utils.io
-   langcheck.utils.progess_bar
+   langcheck.utils.progress_bar


### PR DESCRIPTION
Since #145, we added a new `langcheck.metrics.metric_inputs` module, and renamed a module with typo. (`progess_bar` -> `progress_bar`). This PR is to reflect those changes in the docs.