### PR TITLE
Async call of OpenAISimilarityScorer is slower than sync version

### DIFF
--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -8,13 +8,14 @@ from typing import Any
 
 import torch
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
+from openai.types.create_embedding_response import CreateEmbeddingResponse
 
 from langcheck.utils.progress_bar import tqdm_wrapper
 
 from ..prompts._utils import get_template
 from ..scorer._base import BaseSimilarityScorer
 from ._base import EvalClient, TextResponseWithLogProbs
-from openai.types.create_embedding_response import CreateEmbeddingResponse
+
 
 class OpenAIEvalClient(EvalClient):
     """EvalClient defined for OpenAI API."""


### PR DESCRIPTION
Fixes #160

Although the current code structure can not take the advantage of using Async call, because I see it is not recomended to override the `scorer` func in subclasses, but at least it would not slower than the sync one.