### PR TITLE
0.8.1 patch release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.8.0"
+version = "0.8.1"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     'Jinja2',
     'nlpaug',
     'nltk >= 3.9',
-    'openai >= 1, < 1.47',
+    'openai >= 1',
     'pandas >= 1',
     'plotly >= 5',
     'rouge-score >= 0.1.2',


### PR DESCRIPTION
There are some problems with `httpx==0.28.0` with certain `openai` versions (ref: https://github.com/citadel-ai/langcheck/pull/170#issuecomment-2516899319).

This was fixed in latest `openai`, but we pinned the upper version of `openai` in #159 so that version is not available in `langcheck`.

I did some sanity check and confirmed that the problem we observed is already resolved in the latest `openai`, so let's unpin `openai` upper version and make `v0.8.1` patch release!

The new release will also include #166, #167 and #169, and all of them are minor bug fix / doc tweaks.