### PR TITLE
Added initial support for OpenRouter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     'openai >= 1',
     'pandas >= 1',
     'plotly >= 5',
+    'requests',
     'rouge-score >= 0.1.2',
     'sentence-transformers >= 2',
     'sentencepiece>=0.1.95',

--- a/src/langcheck/metrics/eval_clients/__init__.py
+++ b/src/langcheck/metrics/eval_clients/__init__.py
@@ -40,3 +40,13 @@ except ModuleNotFoundError:
 else:
     __all__.append("PrometheusEvalClient")
     __all__.append("LlamaEvalClient")
+
+try:
+    from langcheck.metrics.eval_clients._openrouter import (
+        OpenRouterEvalClient,  # NOQA: F401
+    )
+except ModuleNotFoundError:
+    pass
+else:
+    __all__.append("OpenRouterEvalClient")
+

--- a/src/langcheck/metrics/eval_clients/__init__.py
+++ b/src/langcheck/metrics/eval_clients/__init__.py
@@ -3,11 +3,13 @@ from langcheck.metrics.eval_clients._openai import (
     AzureOpenAIEvalClient,
     OpenAIEvalClient,
 )
+from langcheck.metrics.eval_clients._openrouter import OpenRouterEvalClient
 
 __all__ = [
     "AzureOpenAIEvalClient",
     "EvalClient",
     "OpenAIEvalClient",
+    "OpenRouterEvalClient",
 ]
 
 try:
@@ -40,13 +42,3 @@ except ModuleNotFoundError:
 else:
     __all__.append("PrometheusEvalClient")
     __all__.append("LlamaEvalClient")
-
-try:
-    from langcheck.metrics.eval_clients._openrouter import (
-        OpenRouterEvalClient,  # NOQA: F401
-    )
-except ModuleNotFoundError:
-    pass
-else:
-    __all__.append("OpenRouterEvalClient")
-

--- a/src/langcheck/metrics/eval_clients/_openrouter.py
+++ b/src/langcheck/metrics/eval_clients/_openrouter.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import os
-import requests
 from collections.abc import Iterable
 from typing import Any
 
+import requests
+
 from ..prompts._utils import get_template
 from ._base import EvalClient
+
 
 class OpenRouterEvalClient(EvalClient):
     """EvalClient defined for the OpenRouter API."""
@@ -32,23 +33,24 @@ class OpenRouterEvalClient(EvalClient):
         prompts: Iterable[str | None],
         config: dict[str, str],
     ) -> list[Any]:
-        def generate_json_dumps(prompt: str) -> dict[str, str]:
+        def generate_json_dumps(prompt: str):
             msg_dict = {
                 "messages": [{
                     "role": "user",
                     "content": prompt,
                 }]
             }
-            return config | msg_dict
+            return msg_dict | config
         responses = []
         for prompt in prompts:
-            response = requests.post(
-                url="https://openrouter.ai/api/v1/chat/completions",
-                headers={
-                    "Authorization": f"Bearer {os.getenv("OPENROUTER_API_KEY")}",
-                   },
-                data=json.dumps(generate_json_dumps(prompt)))
-            responses.append(response.json())
+            if prompt is not None:
+                response = requests.post(
+                    url="https://openrouter.ai/api/v1/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {os.getenv("OPENROUTER_API_KEY")}",
+                       },
+                    data=json.dumps(generate_json_dumps(prompt)))
+                responses.append(response.json())
 
         return responses
 
@@ -73,7 +75,7 @@ class OpenRouterEvalClient(EvalClient):
             config=config,
         )
         response_texts = [
-            response['choices'][0]['message']['content'] if response else None
+            response["choices"][0]["message"]["content"] if response else None
             for response in responses
         ]
 
@@ -128,7 +130,7 @@ class OpenRouterEvalClient(EvalClient):
         config.update(self._openrouter_args or {})
         responses = self._call_api(prompts, config)
         raw_response_texts = [
-            response['choices'][0]['message']['content'] if response else None
+            response["choices"][0]["message"]["content"] if response else None
             for response in responses
         ]
 

--- a/src/langcheck/metrics/eval_clients/_openrouter.py
+++ b/src/langcheck/metrics/eval_clients/_openrouter.py
@@ -26,6 +26,9 @@ class OpenRouterEvalClient(EvalClient):
             ``client.chat.completions.create`` function.
         """
 
+        if os.getenv("OPENROUTER_API_KEY") is None:
+            raise ValueError("OPENROUTER_API_KEY not set!")
+
         self._openrouter_args = openrouter_args
 
     def _call_api(
@@ -47,7 +50,7 @@ class OpenRouterEvalClient(EvalClient):
                 response = requests.post(
                     url="https://openrouter.ai/api/v1/chat/completions",
                     headers={
-                        "Authorization": f"Bearer {os.getenv("OPENROUTER_API_KEY")}",
+                        "Authorization": "Bearer " + (os.getenv("OPENROUTER_API_KEY") or ""),
                        },
                     data=json.dumps(generate_json_dumps(prompt)))
                 responses.append(response.json())

--- a/src/langcheck/metrics/eval_clients/_openrouter.py
+++ b/src/langcheck/metrics/eval_clients/_openrouter.py
@@ -19,6 +19,8 @@ class OpenRouterEvalClient(EvalClient):
     def __init__(
         self,
         openrouter_args: dict[str, str] | None = None,
+        *,
+        system_prompt: str | None = None,
     ):
         """
         Initialize the OpenRouter evaluation client.
@@ -26,13 +28,16 @@ class OpenRouterEvalClient(EvalClient):
         Args:
             openrouter_args: (Optional) dict of additional args to pass in to the
             ``client.chat.completions.create`` function.
+            system_prompt: (Optional) The system prompt to use. If not provided,
+                no system prompt will be used.
         """
 
         if os.getenv("OPENROUTER_API_KEY") is None:
             raise ValueError("OPENROUTER_API_KEY not set!")
 
         self._openrouter_args = openrouter_args
-
+        self._system_prompt = system_prompt
+       
     def _call_api(
         self,
         prompts: Iterable[str | None],
@@ -41,8 +46,14 @@ class OpenRouterEvalClient(EvalClient):
         tqdm_description: str | None = None,
     ) -> list[Any]:
         def generate_json_dumps(prompt: str):
+            system_message = [] if not self._system_prompt else [
+                {
+                    "role": "system",
+                    "content": self._system_prompt,
+                }
+            ]
             msg_dict = {
-                "messages": [{
+                "messages": system_message + [{
                     "role": "user",
                     "content": prompt,
                 }]

--- a/src/langcheck/metrics/eval_clients/_openrouter.py
+++ b/src/langcheck/metrics/eval_clients/_openrouter.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import requests
+from collections.abc import Iterable
+from typing import Any
+
+from ..prompts._utils import get_template
+from ._base import EvalClient
+
+class OpenRouterEvalClient(EvalClient):
+    """EvalClient defined for the OpenRouter API."""
+
+    def __init__(
+        self,
+        openrouter_args: dict[str, str] | None = None,
+    ):
+        """
+        Initialize the OpenRouter evaluation client.
+        
+        Args:
+            openrouter_args: (Optional) dict of additional args to pass in to the
+            ``client.chat.completions.create`` function.
+        """
+
+        self._openrouter_args = openrouter_args
+
+    def _call_api(
+        self,
+        prompts: Iterable[str | None],
+        config: dict[str, str],
+    ) -> list[Any]:
+        def generate_json_dumps(prompt: str) -> dict[str, str]:
+            msg_dict = {
+                "messages": [{
+                    "role": "user",
+                    "content": prompt,
+                }]
+            }
+            return config | msg_dict
+        responses = []
+        for prompt in prompts:
+            response = requests.post(
+                url="https://openrouter.ai/api/v1/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {os.getenv("OPENROUTER_API_KEY")}",
+                   },
+                data=json.dumps(generate_json_dumps(prompt)))
+            responses.append(response.json())
+
+        return responses
+
+    def get_text_responses(
+        self,
+        prompts: Iterable[str],
+    ) -> list[str | None]:
+        """The function that gets responses to the given prompt texts.
+        The user's default OpenRouter model is used by default, but you can
+        configure it by passing the 'model' parameter in the openrouter_args.
+
+        Args:
+            prompts: The prompts you want to get the responses for.
+
+        Returns:
+            A list of responses to the prompts. The responses can be None if the
+            evaluation fails.
+        """
+        config = self._openrouter_args or {}
+        responses = self._call_api(
+            prompts=prompts,
+            config=config,
+        )
+        response_texts = [
+            response['choices'][0]['message']['content'] if response else None
+            for response in responses
+        ]
+
+        return response_texts
+
+    def get_float_score(
+        self,
+        metric_name: str,
+        language: str,
+        unstructured_assessment_result: list[str | None],
+        score_map: dict[str, float],
+    ) -> list[float | None]:
+        """The function that transforms the unstructured assessments (i.e. long
+        texts that describe the evaluation results) into scores.
+
+        Args:
+            metric_name : The name of the metric to be used. (e.g. "toxicity")
+            language: The language of the prompts. (e.g. "en")
+            unstructured_assessment_result: The unstructured assessment results
+                for the given assessment prompts.
+            score_map: The mapping from the short assessment results
+                (e.g. "Good") to the scores.
+        Returns:
+            A list of scores for the given prompts. The scores can be None if
+            the evaluation fails.
+        """
+        if language not in ["en", "ja"]:
+            raise ValueError(f"Unsupported language: {language}")
+
+        options = list(score_map.keys())
+        get_score_template = get_template(f"{language}/get_score/plain_text.j2")
+        get_score_prompts = [
+            get_score_template.render(
+                {
+                    "metric": metric_name,
+                    "unstructured_assessment": unstructured_assessment,
+                    "options": options,
+                }
+            )
+            if unstructured_assessment
+            else None
+            for unstructured_assessment in unstructured_assessment_result
+        ]
+
+        # If there are any Nones in get_score_prompts,
+        # they are excluded from messages to prevent passing those to the model.
+        if isinstance(get_score_prompts, str):
+            prompts = [get_score_prompts]
+        else:
+            prompts = [prompt for prompt in get_score_prompts if prompt is not None]
+        config = {}
+        config.update(self._openrouter_args or {})
+        responses = self._call_api(prompts, config)
+        raw_response_texts = [
+            response['choices'][0]['message']['content'] if response else None
+            for response in responses
+        ]
+
+        responses_for_scoring = []
+        idx_raw_response_texts = 0
+        for idx in range(len(get_score_prompts)):
+            if get_score_prompts[idx] is None:
+                responses_for_scoring.append(None)
+            else:
+                responses_for_scoring.append(
+                    raw_response_texts[idx_raw_response_texts]
+                )
+                idx_raw_response_texts += 1
+
+        def _turn_to_score(response: str | None) -> float | None:
+            if response is None:
+                return None
+            option_found = [option for option in options if option in response]
+            # if response contains multiple options as substrings, return None
+            if len(option_found) != 1:
+                return None
+            return score_map[option_found[0]]
+
+        return [_turn_to_score(response) for response in responses_for_scoring]
+
+    def get_score(
+        self,
+        metric_name: str,
+        language: str,
+        prompts: str | Iterable[str],
+        score_map: dict[str, float],
+    ) -> tuple[list[float | None], list[str | None]]:
+        """Give scores to texts embedded in the given prompts. The function
+        itself calls get_text_responses and get_float_score to get the scores.
+        The function returns the scores and the unstructured explanation
+        strings.
+
+        Args:
+            metric_name: The name of the metric to be used. (e.g. "toxicity")
+            language: The language of the prompts. (e.g. "en")
+            prompts: The prompts that contain the original text to be scored,
+                the evaluation criteria... etc. Typically it is based on the
+                Jinja prompt templates and instantiated withing each metric
+                function.
+            score_map: The mapping from the short assessment results
+                (e.g. "Good") to the scores.
+
+        Returns:
+            A tuple of two lists. The first list contains the scores for each
+            prompt and the second list contains the unstructured assessment
+            results for each prompt. Both can be None if the evaluation fails.
+        """
+        if isinstance(prompts, str):
+            prompts = [prompts]
+        unstructured_assessment_result = self.get_text_responses(prompts)
+        scores = self.get_float_score(
+            metric_name,
+            language,
+            unstructured_assessment_result,
+            score_map,
+        )
+        return scores, unstructured_assessment_result
+
+    def similarity_scorer(self):
+        raise NotImplementedError(
+            "Embedding-based metrics are not supported in OpenRouterEvalClient."
+            "Use other EvalClients to get these metrics."
+        )

--- a/tests/metrics/eval_clients/test_openrouter.py
+++ b/tests/metrics/eval_clients/test_openrouter.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from langcheck.metrics.eval_clients import OpenRouterEvalClient
+
+
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+def test_get_text_response_openrouter(system_prompt):
+    prompts = ["Assess the factual consistency of the generated output..."] * 2
+    answer = "The output is fully factually consistent."
+    mock_response = [{
+        "choices": [
+            {"message": {"content": answer}}
+        ]
+    }] * 2
+    # Calling the _call_api method requires an
+    # OpenRouter API key, so we mock the return value instead
+    with patch(
+            "langcheck.metrics.eval_clients.OpenRouterEvalClient._call_api",
+            return_value=mock_response
+    ):
+        # Set the necessary env vars for the OpenRouterEvalClient
+        os.environ["OPENROUTER_API_KEY"] = "dummy_key"
+        client = OpenRouterEvalClient(system_prompt=system_prompt)
+        responses = client.get_text_responses(prompts)
+        assert len(responses) == len(prompts)
+        for response in responses:
+            assert response == answer
+
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+@pytest.mark.parametrize("language", ["en", "ja"])
+def test_get_float_score_openrouter(system_prompt, language):
+    unstructured_assessment_result: list[str | None] = [
+        "The output is fully factually consistent."
+    ] * 2
+    short_assessment_result = "Fully Consistent"
+    score_map = {short_assessment_result: 1.0}
+
+    mock_response = [{
+        "choices": [
+            {"message": {"content": short_assessment_result}}
+        ]
+    }] * 2
+
+    with patch(
+            "langcheck.metrics.eval_clients.OpenRouterEvalClient._call_api",
+            return_value=mock_response
+    ):
+
+        # Set the necessary env vars for the OpenRouterEvalClient
+        os.environ["OPENROUTER_API_KEY"] = "dummy_key"
+        client = OpenRouterEvalClient(system_prompt=system_prompt)
+
+        scores = client.get_float_score(
+            "dummy_metric", language, unstructured_assessment_result, score_map
+        )
+        assert len(scores) == len(unstructured_assessment_result)
+        for score in scores:
+            assert score == 1.0


### PR DESCRIPTION
See issue #176 
This is still a WIP because I need feedback on the `get_score` and `get_float_score` functions. They have mostly been adapted from the llama client, with a few tokenizer-specific items removed.
Additionally, I'm using `requests` to access the API instead of the OpenAI client, because when users directly access the OpenRouter API they can omit the model name, which cannot be done with the OpenAI client.