### PR TITLE
Support system prompt in EvalClient initializers

### DIFF
--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from collections.abc import Iterable
 from typing import Any
 
@@ -46,6 +47,12 @@ class AnthropicEvalClient(EvalClient):
         self._anthropic_args = anthropic_args or {}
         self._use_async = use_async
         self._system_prompt = system_prompt
+
+        if system_prompt and "system" in self._anthropic_args:
+            warnings.warn(
+                '"system" of anthropic_args will be ignored because '
+                "system_prompt is provided."
+            )
 
     def _call_api(
         self,

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -33,6 +33,8 @@ class AnthropicEvalClient(EvalClient):
             anthropic_args: (Optional) dict of additional args to pass in to
                 the ``client.messages.create`` function
             use_async: (Optional) If True, the async client will be used.
+            system_prompt: (Optional) The system prompt to use. If not provided,
+                no system prompt will be used.
         """
         if anthropic_client:
             self._client = anthropic_client

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -26,6 +26,8 @@ class GeminiEvalClient(EvalClient):
         model_args: dict[str, Any] | None = None,
         generate_content_args: dict[str, Any] | None = None,
         embed_model_name: str | None = None,
+        *,
+        system_prompt: str | None = None,
     ):
         """
         Initialize the Gemini evaluation client. The authentication
@@ -47,12 +49,16 @@ class GeminiEvalClient(EvalClient):
                 ``generate_content`` function.
             embed_model_name: (Optional) The name of the embedding model to use.
                 If not provided, the models/embedding-001 model will be used.
+            system_prompt: (Optional) The system prompt to use. If not provided,
+                no system prompt will be used.
         """
         if model:
             self._model = model
         else:
             configure(api_key=os.getenv("GOOGLE_API_KEY"))
             model_args = model_args or {}
+            if system_prompt:
+                model_args["system_instruction"] = system_prompt
             self._model = GenerativeModel(**model_args)
 
         self._generate_content_args = generate_content_args or {}

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from collections.abc import Iterable
 from typing import Any
 
@@ -61,6 +62,11 @@ class GeminiEvalClient(EvalClient):
             self._structured_assessment_model = GenerativeModel(**model_args)
             # Only add system prompt to the text response model if it is provided
             if system_prompt:
+                if "system_instruction" in model_args:
+                    warnings.warn(
+                        '"system_instruction" of model_args will be ignored because '
+                        "system_prompt is provided."
+                    )
                 model_args["system_instruction"] = system_prompt
             self._text_response_model = GenerativeModel(**model_args)
 

--- a/src/langcheck/metrics/eval_clients/_llama.py
+++ b/src/langcheck/metrics/eval_clients/_llama.py
@@ -63,7 +63,7 @@ class LlamaEvalClient(EvalClient):
             skip_special_tokens=True,
         )
         self._system_prompt = system_prompt
-        self._system_prompts = {
+        self._default_system_prompts = {
             "en": "You are a helpful and competent assistant.",
             "ja": "あなたは誠実で優秀な日本人のアシスタントです。以下は、タスクを説明する指示です。要求を適切に満たす応答を日本語で書きなさい。",
         }
@@ -86,7 +86,7 @@ class LlamaEvalClient(EvalClient):
             raise ValueError(f"Unsupported language: {language}")
 
         if self._system_prompt is None:
-            system_prompt = self._system_prompts[language]
+            system_prompt = self._default_system_prompts[language]
         else:
             system_prompt = self._system_prompt
 
@@ -167,7 +167,7 @@ class LlamaEvalClient(EvalClient):
             [
                 {
                     "role": "system",
-                    "content": self._system_prompts[language],
+                    "content": self._default_system_prompts[language],
                 },
                 {
                     "role": "user",

--- a/src/langcheck/metrics/eval_clients/_llama.py
+++ b/src/langcheck/metrics/eval_clients/_llama.py
@@ -32,6 +32,8 @@ class LlamaEvalClient(EvalClient):
         torch_dtype: str = "bfloat16",
         tensor_parallel_size: int = 1,
         device: str = "cuda",
+        *,
+        system_prompt: str | None = None,
     ):
         """
         Initialize the Llama evaluation client.
@@ -42,6 +44,8 @@ class LlamaEvalClient(EvalClient):
             tensor_parallel_size: The number of GPUs to use for distributed
             execution with tensor parallelism.
             device: The device to load the model on.
+            system_prompt: The system prompt to use. If not provided, default
+                system prompts based on the language will be used.
         """
         self._model = LLM(
             model=model_name,
@@ -58,6 +62,7 @@ class LlamaEvalClient(EvalClient):
             stop="<|eot_id|>",
             skip_special_tokens=True,
         )
+        self._system_prompt = system_prompt
         self._system_prompts = {
             "en": "You are a helpful and competent assistant.",
             "ja": "あなたは誠実で優秀な日本人のアシスタントです。以下は、タスクを説明する指示です。要求を適切に満たす応答を日本語で書きなさい。",
@@ -80,11 +85,16 @@ class LlamaEvalClient(EvalClient):
         if language not in ["en", "ja"]:
             raise ValueError(f"Unsupported language: {language}")
 
+        if self._system_prompt is None:
+            system_prompt = self._system_prompts[language]
+        else:
+            system_prompt = self._system_prompt
+
         messages = [
             [
                 {
                     "role": "system",
-                    "content": self._system_prompts[language],
+                    "content": system_prompt,
                 },
                 {
                     "role": "user",

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -68,14 +68,14 @@ class OpenAIEvalClient(EvalClient):
             except Exception as e:
                 return e
 
-        common_messages = []
+        system_message = []
         if system_prompt:
-            common_messages.append({"role": "system", "content": system_prompt})
+            system_message.append({"role": "system", "content": system_prompt})
 
         # Call API with different seed values for each prompt.
         model_inputs = [
             {
-                "messages": common_messages
+                "messages": system_message
                 + [{"role": "user", "content": prompt}],
                 "seed": i,
                 **config,

--- a/tests/metrics/eval_clients/test_gemini.py
+++ b/tests/metrics/eval_clients/test_gemini.py
@@ -9,7 +9,8 @@ from google.generativeai.types import generation_types
 from langcheck.metrics.eval_clients import GeminiEvalClient
 
 
-def test_get_text_response_gemini():
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+def test_get_text_response_gemini(system_prompt):
     prompts = ["Assess the factual consistency of the generated output..."] * 2
     answer = "The output is fully factually consistent."
     mock_response = Mock(spec=generation_types.GenerateContentResponse)
@@ -23,15 +24,16 @@ def test_get_text_response_gemini():
     ):
         # Set the necessary env vars for the GeminiEvalClient
         os.environ["GOOGLE_API_KEY"] = "dummy_key"
-        client = GeminiEvalClient()
+        client = GeminiEvalClient(system_prompt=system_prompt)
         responses = client.get_text_responses(prompts)
         assert len(responses) == len(prompts)
         for response in responses:
             assert response == answer
 
 
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
 @pytest.mark.parametrize("language", ["en", "de", "ja"])
-def test_get_float_score_gemini(language):
+def test_get_float_score_gemini(system_prompt, language):
     unstructured_assessment_result: list[str | None] = [
         "The output is fully factually consistent."
     ] * 2
@@ -61,7 +63,7 @@ def test_get_float_score_gemini(language):
     ):
         # Set the necessary env vars for the GeminiEvalClient
         os.environ["GOOGLE_API_KEY"] = "dummy_key"
-        client = GeminiEvalClient()
+        client = GeminiEvalClient(system_prompt=system_prompt)
 
         scores = client.get_float_score(
             "dummy_metric", language, unstructured_assessment_result, score_map

--- a/tests/metrics/eval_clients/test_openai.py
+++ b/tests/metrics/eval_clients/test_openai.py
@@ -13,27 +13,30 @@ from langcheck.metrics.eval_clients import (
 )
 
 
-def test_get_text_response_openai():
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+def test_get_text_response_openai(system_prompt):
     prompts = ["Assess the factual consistency of the generated output..."] * 2
     answer = "The output is fully factually consistent."
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [Mock(message=Mock(content=answer))]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the OpenAIEValClient
         os.environ["OPENAI_API_KEY"] = "dummy_key"
-        client = OpenAIEvalClient()
+        client = OpenAIEvalClient(system_prompt=system_prompt)
         responses = client.get_text_responses(prompts)
         assert len(responses) == len(prompts)
         for response in responses:
             assert response == answer
 
 
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
 @pytest.mark.parametrize("language", ["en", "de", "ja"])
-def test_get_float_score_openai(language):
+def test_get_float_score_openai(system_prompt, language):
     unstructured_assessment_result: list[str | None] = [
         "The output is fully factually consistent."
     ] * 2
@@ -42,49 +45,62 @@ def test_get_float_score_openai(language):
 
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [
-        Mock(message=Mock(function_call=Mock(
-            arguments=json.dumps({"assessment": short_assessment_result}))))
+        Mock(
+            message=Mock(
+                function_call=Mock(
+                    arguments=json.dumps(
+                        {"assessment": short_assessment_result}
+                    )
+                )
+            )
+        )
     ]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the OpenAIEValClient
         os.environ["OPENAI_API_KEY"] = "dummy_key"
-        client = OpenAIEvalClient()
+        client = OpenAIEvalClient(system_prompt=system_prompt)
 
-        scores = client.get_float_score("dummy_metric", language,
-                                        unstructured_assessment_result,
-                                        score_map)
+        scores = client.get_float_score(
+            "dummy_metric", language, unstructured_assessment_result, score_map
+        )
         assert len(scores) == len(unstructured_assessment_result)
         for score in scores:
             assert score == 1.0
 
 
-def test_get_text_response_azure_openai():
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+def test_get_text_response_azure_openai(system_prompt):
     prompts = ["Assess the factual consistency of the generated output..."] * 2
     answer = "The output is fully factually consistent."
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [Mock(message=Mock(content=answer))]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the 'azure_openai' model type
         os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
         os.environ["OPENAI_API_VERSION"] = "dummy_version"
         os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
 
-        client = AzureOpenAIEvalClient(text_model_name="foo bar")
+        client = AzureOpenAIEvalClient(
+            text_model_name="foo bar", system_prompt=system_prompt
+        )
         responses = client.get_text_responses(prompts)
         assert len(responses) == len(prompts)
         for response in responses:
             assert response == answer
 
 
-def test_get_float_score_azure_openai():
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+def test_get_float_score_azure_openai(system_prompt):
     unstructured_assessment_result: list[str | None] = [
         "The output is fully factually consistent."
     ] * 2
@@ -93,23 +109,33 @@ def test_get_float_score_azure_openai():
 
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [
-        Mock(message=Mock(function_call=Mock(
-            arguments=json.dumps({"assessment": short_assessment_result}))))
+        Mock(
+            message=Mock(
+                function_call=Mock(
+                    arguments=json.dumps(
+                        {"assessment": short_assessment_result}
+                    )
+                )
+            )
+        )
     ]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the 'azure_openai' model type
         os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
         os.environ["OPENAI_API_VERSION"] = "dummy_version"
         os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
-        client = AzureOpenAIEvalClient(text_model_name="foo bar")
+        client = AzureOpenAIEvalClient(
+            text_model_name="foo bar", system_prompt=system_prompt
+        )
 
-        scores = client.get_float_score("dummy_metric", "en",
-                                        unstructured_assessment_result,
-                                        score_map)
+        scores = client.get_float_score(
+            "dummy_metric", "en", unstructured_assessment_result, score_map
+        )
         assert len(scores) == len(unstructured_assessment_result)
         for score in scores:
             assert score == 1.0


### PR DESCRIPTION
Added `system_prompt` as an argument of each `EvalClient` classes. With this, users can inject their specific instruction about the behavior of evaluators. The system prompt is used only in the text generation stage, and not in the score extraction stage.

One potential application is using the default `en` metrics to generate non-English explanations by adding "Answer in xx (Language)" instruction.

```
eval_model = LlamaEvalClient(
    model_name="meta-llama/Llama-3.1-8B-Instruct",
    system_prompt="日本語で回答してください",
)

scores = langcheck.metrics.toxicity(
    "Hello, how are you?", eval_model=eval_model
)

print(scores.explanations[0])
# => この問題を段階的に解決していきます。....

```