### PR TITLE
Add ruff format test to CI

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -31,9 +31,12 @@ jobs:
           pip install -U --upgrade pip
           pip install -U .[all,dev]
 
-      # Run the ruff lint & format test
-      - name: Ruff
+      # Run the ruff lint
+      - name: Ruff check
         run: ruff check --output-format=github src/ tests/
+
+      # Run the ruff format
+      - name: Ruff format
         run: ruff format --check src/ tests/
 
       # Run the pyright test

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -31,9 +31,11 @@ jobs:
           pip install -U --upgrade pip
           pip install -U .[all,dev]
 
-      # Run the ruff format test
+      # Run the ruff lint & format test
       - name: Ruff
-        run: ruff check src/ tests/
+        run: ruff check --output-format=github src/ tests/
+        run: ruff format --check src/ tests/
 
+      # Run the pyright test
       - name: Pyright
         run: pyright .

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,7 +29,7 @@ We auto-format the code with [ruff](https://github.com/astral-sh/ruff).
 Please format your code with following command before you submit a pull request.
 
 ```bash
-ruff format src/ tests/
+ruff format  # Format all files in the current directory (and any subdirectories)
 ```
 
 ## Running Static Checks
@@ -37,8 +37,8 @@ We have static checks with [ruff](https://github.com/astral-sh/ruff) and [pyrigh
 Please make sure that your code passes those two commands as well.
 
 ```bash
-ruff check src/ tests/
-pyright .
+ruff check  # Ruff lint all files in the current directory (and any subdirectories)
+pyright  # Pyright lint all files in the current directory (and any subdirectories)
 ```
 
 ## Running Tests

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,9 +24,17 @@ prompt generated_output reference_output  metric_value
 2   None                a             None             0
 ```
 
+## Running Formatter
+We auto-format the code with [ruff](https://github.com/astral-sh/ruff).
+Please format your code with following command before you submit a pull request.
+
+```bash
+ruff format src/ tests/
+```
+
 ## Running Static Checks
 We have static checks with [ruff](https://github.com/astral-sh/ruff) and [pyright](https://github.com/microsoft/pyright).
-Please make sure that your code passes those two commands before you submit a pull request.
+Please make sure that your code passes those two commands as well.
 
 ```bash
 ruff check src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ repository    = "https://github.com/citadel-ai/langcheck"
 lint.select = ["E4", "E7", "E9", "F", "I", "Q"]
 line-length=80
 exclude = [
-    "build", "venv"
+    "build", "venv", "docs"
 ]
 
 [tool.pyright]

--- a/src/langcheck/augment/_common/_jailbreak_template.py
+++ b/src/langcheck/augment/_common/_jailbreak_template.py
@@ -55,12 +55,18 @@ def jailbreak_template_common(
         for template_name, path_to_template in custom_templates:
             # validation
             if template_name in available_templates:
-                raise ValueError(f"A template with the name {template_name} already exists!")
+                raise ValueError(
+                    f"A template with the name {template_name} already exists!"
+                )
             template_file = Path(path_to_template)
             if not template_file.exists():
-                raise ValueError(f"Custom template file {path_to_template} does not exist!")
+                raise ValueError(
+                    f"Custom template file {path_to_template} does not exist!"
+                )
             if not path_to_template.endswith(".j2"):
-                raise ValueError("The custom template file must be a Jinja2 template file with the extension '.j2'!")
+                raise ValueError(
+                    "The custom template file must be a Jinja2 template file with the extension '.j2'!"
+                )
             available_templates = [*available_templates, template_name]
 
     # Validation on the length of templates and num_perturbations
@@ -89,9 +95,17 @@ def jailbreak_template_common(
 
         for template_name in selected_templates:
             # if the template is from custom_templates, fetch the path from there
-            if custom_templates is not None and any(name == template_name for name, _ in custom_templates):
-                template_path = next(path for name, path in custom_templates if name == template_name)
-                template = Template(Path(template_path).read_text(encoding="utf-8"))
+            if custom_templates is not None and any(
+                name == template_name for name, _ in custom_templates
+            ):
+                template_path = next(
+                    path
+                    for name, path in custom_templates
+                    if name == template_name
+                )
+                template = Template(
+                    Path(template_path).read_text(encoding="utf-8")
+                )
             else:
                 template = get_template(
                     f"{language}/jailbreak_templates/{template_name}.j2"

--- a/src/langcheck/augment/en/_gender/_gender_pronouns.py
+++ b/src/langcheck/augment/en/_gender/_gender_pronouns.py
@@ -11,17 +11,21 @@ class _BaseGenderPronouns:
     reflexive: str
 
 
-_FEMALE_PRONOUNS = _BaseGenderPronouns(subject="she",
-                                       dependent_possessive="her",
-                                       object="her",
-                                       independent_possessive="hers",
-                                       reflexive="herself")
+_FEMALE_PRONOUNS = _BaseGenderPronouns(
+    subject="she",
+    dependent_possessive="her",
+    object="her",
+    independent_possessive="hers",
+    reflexive="herself",
+)
 
-_MALE_PRONOUNS = _BaseGenderPronouns(subject="he",
-                                     dependent_possessive="his",
-                                     object="him",
-                                     independent_possessive="his",
-                                     reflexive="himself")
+_MALE_PRONOUNS = _BaseGenderPronouns(
+    subject="he",
+    dependent_possessive="his",
+    object="him",
+    independent_possessive="his",
+    reflexive="himself",
+)
 
 _PLURAL_PRONOUNS = _BaseGenderPronouns(
     subject="they",
@@ -126,12 +130,14 @@ _NEO_PRONOUNS_LIST = [
         object="aer",
         independent_possessive="aers",
         reflexive="aerself",
-    )
+    ),
 ]
 
-_PRONOUNS_DICT = MappingProxyType({
-    "plural": [_PLURAL_PRONOUNS],
-    "male": [_MALE_PRONOUNS],
-    "female": [_FEMALE_PRONOUNS],
-    "neutral": _NEO_PRONOUNS_LIST + [_PLURAL_PRONOUNS],
-})
+_PRONOUNS_DICT = MappingProxyType(
+    {
+        "plural": [_PLURAL_PRONOUNS],
+        "male": [_MALE_PRONOUNS],
+        "female": [_FEMALE_PRONOUNS],
+        "neutral": _NEO_PRONOUNS_LIST + [_PLURAL_PRONOUNS],
+    }
+)

--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -92,12 +92,12 @@ def custom_evaluator(
         required_params=[],
     )
 
-    assert Path(
-        template_path
-    ).exists(), f"Prompt template file {template_path} does not exist."
-    assert template_path.endswith(
-        ".j2"
-    ), 'The prompt template file must be a Jinja2 template file with the extension ".j2"'
+    assert Path(template_path).exists(), (
+        f"Prompt template file {template_path} does not exist."
+    )
+    assert template_path.endswith(".j2"), (
+        'The prompt template file must be a Jinja2 template file with the extension ".j2"'
+    )
 
     prompt_template_source = Path(template_path).read_text(encoding="utf-8")
     metric_inputs.validate_template(prompt_template_source)
@@ -194,12 +194,12 @@ def custom_pairwise_evaluator(
         required_params=[],
     )
 
-    assert Path(
-        template_path
-    ).exists(), f"Prompt template file {template_path} does not exist."
-    assert template_path.endswith(
-        ".j2"
-    ), 'The prompt template file must be a Jinja2 template file with the extension ".j2"'
+    assert Path(template_path).exists(), (
+        f"Prompt template file {template_path} does not exist."
+    )
+    assert template_path.endswith(".j2"), (
+        'The prompt template file must be a Jinja2 template file with the extension ".j2"'
+    )
 
     prompt_template_source = Path(template_path).read_text(encoding="utf-8")
     metric_inputs.validate_template(prompt_template_source)

--- a/src/langcheck/metrics/de/_translation.py
+++ b/src/langcheck/metrics/de/_translation.py
@@ -14,10 +14,12 @@ class Translate:
         Args:
             model_name: The name of the model to use for translation
         """
-        self._translation_pipeline = pipeline("translation",
-                                              model=model_name,
-                                              tokenizer=model_name,
-                                              truncation=True)
+        self._translation_pipeline = pipeline(
+            "translation",
+            model=model_name,
+            tokenizer=model_name,
+            truncation=True,
+        )
         self._max_length = self._translation_pipeline.model.config.max_length
 
     def _translate(self, texts: str) -> str:
@@ -30,20 +32,23 @@ class Translate:
             The translated texts
         """
         tokenization = self._translation_pipeline.tokenizer(
-            texts, return_tensors="pt")  # type: ignore
+            texts, return_tensors="pt"
+        )  # type: ignore
         if tokenization.input_ids.shape[1] > (self._max_length / 2):
             # Split the text into blocks, if it is too long
             # starting from 2 * num_tokens / max_length to be sure
             # NB: this comes from a few 100 tests, but it is not a science
-            blocks = floor(2 * tokenization.input_ids.shape[1] /
-                           self._max_length)
+            blocks = floor(
+                2 * tokenization.input_ids.shape[1] / self._max_length
+            )
             sentences = sent_tokenize(texts)
             # Split sentences into a number of blocks, e.g., 2 blocks = 2 groups
             len_block = floor(len(sentences) / blocks) + 1
             sentences_list = []
             for i in range(blocks):
-                sentences_list.append(sentences[i * len_block:(i + 1) *
-                                                len_block])
+                sentences_list.append(
+                    sentences[i * len_block : (i + 1) * len_block]
+                )
             text_list = [" ".join(sent) for sent in sentences_list]
         else:
             text_list = [texts]

--- a/src/langcheck/metrics/de/reference_based_text_quality.py
+++ b/src/langcheck/metrics/de/reference_based_text_quality.py
@@ -66,9 +66,9 @@ def semantic_similarity(
     if eval_model == "local":
         scorer = SentenceTransformerSimilarityScorer(language=LANG)
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
         scorer = eval_model.similarity_scorer()
 
     scores = scorer.score(generated_outputs, reference_outputs)

--- a/src/langcheck/metrics/de/reference_free_text_quality.py
+++ b/src/langcheck/metrics/de/reference_free_text_quality.py
@@ -86,9 +86,9 @@ def sentiment(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         sentiment_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name
@@ -194,9 +194,9 @@ def fluency(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         fluency_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name
@@ -273,9 +273,9 @@ def toxicity(
         )
 
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         toxicity_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name

--- a/src/langcheck/metrics/de/source_based_text_quality.py
+++ b/src/langcheck/metrics/de/source_based_text_quality.py
@@ -67,9 +67,9 @@ def factual_consistency(
 
     metric_name = "factual_consistency"
     if eval_model != "local":  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         factual_consistency_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name

--- a/src/langcheck/metrics/en/pairwise_text_quality.py
+++ b/src/langcheck/metrics/en/pairwise_text_quality.py
@@ -42,9 +42,9 @@ def simulated_annotators(
     """
     # Load preprocessed preference data
     preference_data = load_few_shot_examples(preference_data_path)
-    assert (
-        len(preference_data) >= k
-    ), "Not enough examples in the preference data"
+    assert len(preference_data) >= k, (
+        "Not enough examples in the preference data"
+    )
 
     if seed is not None:
         random.seed(seed)
@@ -167,9 +167,9 @@ def pairwise_comparison(
         required_params=[],
     )
 
-    assert (
-        eval_model is not None
-    ), "You must pass an EvalClient instance to the pairwise_comparison function."
+    assert eval_model is not None, (
+        "You must pass an EvalClient instance to the pairwise_comparison function."
+    )
 
     pairwise_comparison_assessment_to_score = {
         "Response B": 1.0,

--- a/src/langcheck/metrics/en/reference_based_text_quality.py
+++ b/src/langcheck/metrics/en/reference_based_text_quality.py
@@ -108,9 +108,9 @@ def semantic_similarity(
     if eval_model == "local":
         scorer = SentenceTransformerSimilarityScorer(language="en")
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
         scorer = eval_model.similarity_scorer()
 
     scores = scorer.score(generated_outputs, reference_outputs)

--- a/src/langcheck/metrics/en/reference_free_text_quality.py
+++ b/src/langcheck/metrics/en/reference_free_text_quality.py
@@ -75,9 +75,9 @@ def sentiment(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         sentiment_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name
@@ -184,9 +184,9 @@ def fluency(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         fluency_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name
@@ -294,9 +294,9 @@ def toxicity(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         toxicity_assessment_to_score = {
             # The v1 prompt returns the toxicity on a scale of 1 to 5
@@ -313,9 +313,9 @@ def toxicity(
                 "Nontoxic": 0,
             },
         }
-        assert (
-            eval_prompt_version in toxicity_assessment_to_score
-        ), f"Invalid eval_prompt_version: {eval_prompt_version}. The valid versions are {list(toxicity_assessment_to_score.keys())}."
+        assert eval_prompt_version in toxicity_assessment_to_score, (
+            f"Invalid eval_prompt_version: {eval_prompt_version}. The valid versions are {list(toxicity_assessment_to_score.keys())}."
+        )
 
         toxicity_template = eval_model.load_prompt_template(
             language=LANG,

--- a/src/langcheck/metrics/en/source_based_text_quality.py
+++ b/src/langcheck/metrics/en/source_based_text_quality.py
@@ -79,9 +79,9 @@ def factual_consistency(
             language="en",
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         factual_consistency_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -411,31 +411,31 @@ class OpenAISimilarityScorer(BaseSimilarityScorer):
         self._use_async = use_async
 
     async def _async_embed(self, inputs: list[str]) -> CreateEmbeddingResponse:
-      """Embed the inputs using the OpenAI API in async mode."""
-      assert isinstance(self.openai_client, AsyncOpenAI)
-      if self.openai_args:
-          responses = await self.openai_client.embeddings.create(
-              input=inputs, **self.openai_args
-          )
-      else:
-          responses = await self.openai_client.embeddings.create(
-              input=inputs, model="text-embedding-3-small"
-          )
-      return responses
-      
+        """Embed the inputs using the OpenAI API in async mode."""
+        assert isinstance(self.openai_client, AsyncOpenAI)
+        if self.openai_args:
+            responses = await self.openai_client.embeddings.create(
+                input=inputs, **self.openai_args
+            )
+        else:
+            responses = await self.openai_client.embeddings.create(
+                input=inputs, model="text-embedding-3-small"
+            )
+        return responses
+
     def _embed(self, inputs: list[str]) -> torch.Tensor:
         """Embed the inputs using the OpenAI API."""
 
         # TODO: Fix that this async call could be much slower than the sync
         # version. https://github.com/citadel-ai/langcheck/issues/160
         if self._use_async:
-          try:
-            loop = asyncio.get_event_loop()
-          except RuntimeError:  # pragma: py-lt-310
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-          embed_response = loop.run_until_complete(self._async_embed(inputs))
-          embeddings = [item.embedding for item in embed_response.data]
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:  # pragma: py-lt-310
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+            embed_response = loop.run_until_complete(self._async_embed(inputs))
+            embeddings = [item.embedding for item in embed_response.data]
         else:
             assert isinstance(self.openai_client, OpenAI)
 

--- a/src/langcheck/metrics/ja/_tokenizers.py
+++ b/src/langcheck/metrics/ja/_tokenizers.py
@@ -11,11 +11,11 @@ _PUNCTUATIONS = ["、", "。", "，", "．", ",", ".", "?", "!", "？", "！"]
 
 
 class _JapaneseTokenizer(BaseTokenizer):
-
     @abc.abstractmethod
     def _tokenize(self, text: str) -> Iterator[str]:
         raise NotImplementedError(
-            "Tokenizer for Japanese must override `_tokenize()` method")
+            "Tokenizer for Japanese must override `_tokenize()` method"
+        )
 
     def tokenize(self, text: str) -> list[str]:
         tokens = self._tokenize(text)
@@ -40,7 +40,6 @@ class MeCabTokenizer(_JapaneseTokenizer):
     """
 
     class _MeCabNodeSurfaceIterator(Iterator):
-
         def __init__(self, node) -> None:
             self._node = node
             # Skip BOS.
@@ -65,13 +64,15 @@ class MeCabTokenizer(_JapaneseTokenizer):
                 "No module named 'MeCab'.\n"
                 "Since 'MeCabTokenizer' is an optional feature, 'MeCab' "
                 "is not installed by default along with langcheck. Please "
-                "set up 'MeCab' on your own.")
+                "set up 'MeCab' on your own."
+            )
 
         self.tokenizer = MeCab.Tagger()
 
     def _tokenize(self, text):
         return MeCabTokenizer._MeCabNodeSurfaceIterator(
-            self.tokenizer.parseToNode(text))
+            self.tokenizer.parseToNode(text)
+        )
 
 
 class JanomeTokenizer(_JapaneseTokenizer):

--- a/src/langcheck/metrics/ja/pairwise_text_quality.py
+++ b/src/langcheck/metrics/ja/pairwise_text_quality.py
@@ -53,9 +53,9 @@ def pairwise_comparison(
         required_params=[],
     )
 
-    assert (
-        eval_model is not None
-    ), "You must pass an EvalClient instance to the pairwise_comparison function."
+    assert eval_model is not None, (
+        "You must pass an EvalClient instance to the pairwise_comparison function."
+    )
 
     pairwise_comparison_assessment_to_score = {
         "Response B": 1.0,

--- a/src/langcheck/metrics/ja/reference_based_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_based_text_quality.py
@@ -111,9 +111,9 @@ def semantic_similarity(
     if eval_model == "local":
         scorer = SentenceTransformerSimilarityScorer(language="ja")
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
         scorer = eval_model.similarity_scorer()
 
     scores = scorer.score(generated_outputs, reference_outputs)

--- a/src/langcheck/metrics/ja/reference_free_text_quality.py
+++ b/src/langcheck/metrics/ja/reference_free_text_quality.py
@@ -75,9 +75,9 @@ def sentiment(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         sentiment_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name
@@ -195,9 +195,9 @@ def toxicity(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
         toxicity_assessment_to_score = {
             # The v1 prompt returns the toxicity on a scale of 1 to 5
             "v1": {
@@ -213,9 +213,9 @@ def toxicity(
                 "Nontoxic": 0,
             },
         }
-        assert (
-            eval_prompt_version in toxicity_assessment_to_score
-        ), f"Invalid eval_prompt_version: {eval_prompt_version}. The valid versions are {list(toxicity_assessment_to_score.keys())}."
+        assert eval_prompt_version in toxicity_assessment_to_score, (
+            f"Invalid eval_prompt_version: {eval_prompt_version}. The valid versions are {list(toxicity_assessment_to_score.keys())}."
+        )
 
         toxicity_template = eval_model.load_prompt_template(
             language=LANG,
@@ -324,9 +324,9 @@ def fluency(
             language=LANG,
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         fluency_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name

--- a/src/langcheck/metrics/ja/source_based_text_quality.py
+++ b/src/langcheck/metrics/ja/source_based_text_quality.py
@@ -83,9 +83,9 @@ def factual_consistency(
             language="en",
         )
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         factual_consistency_template = eval_model.load_prompt_template(
             language=LANG, metric_name=metric_name

--- a/src/langcheck/metrics/metric_inputs.py
+++ b/src/langcheck/metrics/metric_inputs.py
@@ -331,26 +331,26 @@ class MetricInputs:
         )
 
         allowed_params = self.prompt_var_to_input_name_mapping.keys()
-        assert all(
-            param in allowed_params for param in expected_params
-        ), f"The prompt template contains invalid parameters. The allowed parameters are {allowed_params} but the prompt template expects the parameters {expected_params}"
+        assert all(param in allowed_params for param in expected_params), (
+            f"The prompt template contains invalid parameters. The allowed parameters are {allowed_params} but the prompt template expects the parameters {expected_params}"
+        )
 
         for param in expected_params:
             arg_key = self.prompt_var_to_input_name_mapping[param]
             if arg_key in self.individual_inputs:
-                assert (
-                    self.individual_inputs[arg_key] is not None
-                ), f'The prompt template expects the parameter "{param}" but it is not provided.'
+                assert self.individual_inputs[arg_key] is not None, (
+                    f'The prompt template expects the parameter "{param}" but it is not provided.'
+                )
             else:
                 pairwise_inputs_a, pairwise_inputs_b = self.pairwise_inputs[
                     arg_key
                 ]
-                assert (
-                    pairwise_inputs_a is not None
-                ), f'The prompt template expects the parameter "{param}_a" but it is not provided.'
-                assert (
-                    pairwise_inputs_b is not None
-                ), f'The prompt template expects the parameter "{param}_b" but it is not provided.'
+                assert pairwise_inputs_a is not None, (
+                    f'The prompt template expects the parameter "{param}_a" but it is not provided.'
+                )
+                assert pairwise_inputs_b is not None, (
+                    f'The prompt template expects the parameter "{param}_b" but it is not provided.'
+                )
 
     def get_required_individual_input(self, key: str) -> list[str]:
         """Get the list of a required parameter in individual_inputs.

--- a/src/langcheck/metrics/metric_value.py
+++ b/src/langcheck/metrics/metric_value.py
@@ -48,7 +48,7 @@ class MetricValue(Generic[NumericType]):
         """Returns a string representation of an
         :class:`~langcheck.metrics.metric_value.MetricValue` object.
         """
-        return f"Metric: {self.metric_name}\n" f"{self.to_df()}"
+        return f"Metric: {self.metric_name}\n{self.to_df()}"
 
     def __repr__(self) -> str:
         """Returns a string representation of an
@@ -61,9 +61,7 @@ class MetricValue(Generic[NumericType]):
         :class:`~langcheck.metrics.metric_value.MetricValue`, which is
         automatically called by Jupyter notebooks.
         """
-        return (
-            f"Metric: {self.metric_name}<br>" f"{self.to_df()._repr_html_()}"  # type: ignore
-        )
+        return f"Metric: {self.metric_name}<br>{self.to_df()._repr_html_()}"  # type: ignore
 
     def __lt__(self, threshold: float | int) -> MetricValueWithThreshold:
         """Allows the user to write a `metric_value < 0.5` expression."""
@@ -260,7 +258,7 @@ class MetricValueWithThreshold(MetricValue):
         """
         return (
             f"Metric: {self.metric_name}\n"
-            f"Pass Rate: {round(self.pass_rate*100, 2)}%\n"
+            f"Pass Rate: {round(self.pass_rate * 100, 2)}%\n"
             f"{self.to_df()}"
         )
 
@@ -277,7 +275,7 @@ class MetricValueWithThreshold(MetricValue):
         """
         return (
             f"Metric: {self.metric_name}<br>"
-            f"Pass Rate: {round(self.pass_rate*100, 2)}%<br>"
+            f"Pass Rate: {round(self.pass_rate * 100, 2)}%<br>"
             f"{self.to_df()._repr_html_()}"  # type: ignore
         )
 

--- a/src/langcheck/metrics/scorer/detoxify_models.py
+++ b/src/langcheck/metrics/scorer/detoxify_models.py
@@ -117,9 +117,9 @@ class DetoxifyScorer(BaseSingleScorer):
         ):
             raise ValueError("Some of the inputs are too long.")
 
-        assert (
-            self.overflow_strategy == "nullify"
-        ), 'Overflow strategy is invalid. The value should be either "raise", "truncate" or "nullify".'
+        assert self.overflow_strategy == "nullify", (
+            'Overflow strategy is invalid. The value should be either "raise", "truncate" or "nullify".'
+        )
 
         # Return the padded & truncated tokens.
         # The user needs to exclude the invalid tokens from the results.

--- a/src/langcheck/metrics/scorer/hf_models.py
+++ b/src/langcheck/metrics/scorer/hf_models.py
@@ -70,9 +70,9 @@ class AutoModelForSequenceClassificationScorer(BaseSingleScorer):
         ):
             raise ValueError("Some of the inputs are too long.")
 
-        assert (
-            self.overflow_strategy == "nullify"
-        ), 'Overflow strategy is invalid. The value should be either "raise", "truncate" or "nullify".'
+        assert self.overflow_strategy == "nullify", (
+            'Overflow strategy is invalid. The value should be either "raise", "truncate" or "nullify".'
+        )
 
         # Return the padded & truncated tokens.
         # The user needs to exclude the invalid tokens from the results.

--- a/src/langcheck/metrics/zh/__init__.py
+++ b/src/langcheck/metrics/zh/__init__.py
@@ -13,7 +13,13 @@ from langcheck.metrics.zh.reference_free_text_quality import (
 from langcheck.metrics.zh.source_based_text_quality import factual_consistency
 
 __all__ = [
-    "HanLPTokenizer", "semantic_similarity", "rouge1", "rouge2", "rougeL",
-    "factual_consistency", "sentiment", "toxicity",
-    "xuyaochen_report_readability"
+    "HanLPTokenizer",
+    "semantic_similarity",
+    "rouge1",
+    "rouge2",
+    "rougeL",
+    "factual_consistency",
+    "sentiment",
+    "toxicity",
+    "xuyaochen_report_readability",
 ]

--- a/src/langcheck/metrics/zh/reference_based_text_quality.py
+++ b/src/langcheck/metrics/zh/reference_based_text_quality.py
@@ -73,9 +73,9 @@ def semantic_similarity(
     if eval_model == "local":
         scorer = SentenceTransformerSimilarityScorer(language="zh")
     else:  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
         scorer = eval_model.similarity_scorer()
     scores = scorer.score(generated_outputs, reference_outputs)
 

--- a/src/langcheck/metrics/zh/reference_free_text_quality.py
+++ b/src/langcheck/metrics/zh/reference_free_text_quality.py
@@ -59,9 +59,9 @@ def sentiment(
     )
 
     if eval_model != "local":  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         # This reuses the English prompt.
         # TODO: Update this to use a Chinese prompt.
@@ -140,9 +140,9 @@ def toxicity(
     )
 
     if eval_model != "local":  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
 
         # This reuses the English prompt.
         # TODO: Update this to use a Chinese prompt.

--- a/src/langcheck/metrics/zh/source_based_text_quality.py
+++ b/src/langcheck/metrics/zh/source_based_text_quality.py
@@ -65,9 +65,9 @@ def factual_consistency(
     )
 
     if eval_model != "local":  # EvalClient
-        assert isinstance(
-            eval_model, EvalClient
-        ), "An EvalClient must be provided for non-local model types."
+        assert isinstance(eval_model, EvalClient), (
+            "An EvalClient must be provided for non-local model types."
+        )
         metric_value = en_factual_consistency(
             generated_outputs, sources, prompts, eval_model
         )

--- a/src/langcheck/plot/_css.py
+++ b/src/langcheck/plot/_css.py
@@ -5,18 +5,18 @@ GLOBAL_CSS = {
     "font-family": "sans-serif",
     "font-size": "14px",
     "padding": "10px",
-    "background-color": "#fff"
+    "background-color": "#fff",
 }
 
 INPUT_CSS = {
     "padding": "5px 8px",
     "border": "1px solid #D1D1D1",
     "border-radius": "4px",
-    "margin-bottom": "6px"
+    "margin-bottom": "6px",
 }
 
 NUM_RESULTS_CSS = {
     "background-color": "white",
     "font-style": "italic",
-    "color": "grey"
+    "color": "grey",
 }

--- a/tests/augment/en/test_jailbreak_template.py
+++ b/tests/augment/en/test_jailbreak_template.py
@@ -51,10 +51,13 @@ def test_jailbreak_template(
             # assert that `idx`th template includes the original instance
             assert instances[i] in results[idx]
 
+
 def test_custom_jailbreak_template(tmp_path):
     template_file = tmp_path / "custom_template.j2"
     template_file.write_text("Custom jailbreak: {{input_query}}")
     custom_templates = [("custom", str(template_file))]
-    results = jailbreak_template("Hello, world", templates=["custom"], custom_templates=custom_templates)
+    results = jailbreak_template(
+        "Hello, world", templates=["custom"], custom_templates=custom_templates
+    )
     assert len(results) == 1
     assert results[0] == "Custom jailbreak: Hello, world"

--- a/tests/augment/en/test_synonym.py
+++ b/tests/augment/en/test_synonym.py
@@ -14,16 +14,26 @@ from langcheck.augment.en import synonym
         ("Hello, world!", 2, ["Hullo, world!", "Hello, earth!"]),
         (["Hello, world!"], 1, ["Hullo, world!"]),
         ("Hello, world!", 2, ["Hullo, world!", "Hello, earth!"]),
-        (["Hello, world!", "I have a pen. I have an apple"
-         ], 1, ["Hullo, world!", "I have a pen. I have an malus pumila"]),
-        (["Hello, world!", "I have a pen. I have an apple"], 2, [
-            "Hullo, world!", "Hello, earth!", "I get a pen. I have an apple",
-            "I have a pen. I have an orchard apple tree"
-        ]),
+        (
+            ["Hello, world!", "I have a pen. I have an apple"],
+            1,
+            ["Hullo, world!", "I have a pen. I have an malus pumila"],
+        ),
+        (
+            ["Hello, world!", "I have a pen. I have an apple"],
+            2,
+            [
+                "Hullo, world!",
+                "Hello, earth!",
+                "I get a pen. I have an apple",
+                "I have a pen. I have an orchard apple tree",
+            ],
+        ),
     ],
 )
-def test_synonym(instances: list[str] | str, num_perturbations: int,
-                 expected: list[str]):
+def test_synonym(
+    instances: list[str] | str, num_perturbations: int, expected: list[str]
+):
     seed = 42
     random.seed(seed)
     actual = synonym(instances, num_perturbations=num_perturbations)

--- a/tests/augment/ja/test_jailbreak_template.py
+++ b/tests/augment/ja/test_jailbreak_template.py
@@ -49,10 +49,13 @@ def test_jailbreak_template(
             # assert that `idx`th template includes the original instance
             assert instances[i] in results[idx]
 
+
 def test_custom_jailbreak_template(tmp_path):
     template_file = tmp_path / "custom_template.j2"
     template_file.write_text("Custom jailbreak: {{input_query}}")
     custom_templates = [("custom", str(template_file))]
-    results = jailbreak_template("Hello, world", templates=["custom"], custom_templates=custom_templates)
+    results = jailbreak_template(
+        "Hello, world", templates=["custom"], custom_templates=custom_templates
+    )
     assert len(results) == 1
     assert results[0] == "Custom jailbreak: Hello, world"

--- a/tests/augment/ja/test_synonym.py
+++ b/tests/augment/ja/test_synonym.py
@@ -16,13 +16,26 @@ pytestmark = pytest.mark.optional
         ("地球は青かった。", 2, ["アースは青かった。", "アースは青かった。"]),
         (["地球は青かった。"], 1, ["アースは青かった。"]),
         ("地球は青かった。", 2, ["アースは青かった。", "アースは青かった。"]),
-        (["地球は青かった。", "先行きが不安だ。"], 1, ["アースは青かった。", "将来が畏れだ。"]),
-        (["地球は青かった。", "先行きが不安だ。"
-         ], 2, ["アースは青かった。", "アースは青かった。", "フューチャーが気掛かりだ。", "行く先が畏れだ。"]),
+        (
+            ["地球は青かった。", "先行きが不安だ。"],
+            1,
+            ["アースは青かった。", "将来が畏れだ。"],
+        ),
+        (
+            ["地球は青かった。", "先行きが不安だ。"],
+            2,
+            [
+                "アースは青かった。",
+                "アースは青かった。",
+                "フューチャーが気掛かりだ。",
+                "行く先が畏れだ。",
+            ],
+        ),
     ],
 )
-def test_synonym(instances: list[str] | str, num_perturbations: int,
-                 expected: list[str]):
+def test_synonym(
+    instances: list[str] | str, num_perturbations: int, expected: list[str]
+):
     seed = 42
     random.seed(seed)
     actual = synonym(instances, num_perturbations=num_perturbations)

--- a/tests/metrics/de/test_reference_based_text_quality.py
+++ b/tests/metrics/de/test_reference_based_text_quality.py
@@ -24,9 +24,9 @@ from tests.utils import is_close
     ],
 )
 def test_semantic_similarity_identical(generated_outputs, reference_outputs):
-    metric_value = semantic_similarity(generated_outputs,
-                                       reference_outputs,
-                                       eval_model="local")
+    metric_value = semantic_similarity(
+        generated_outputs, reference_outputs, eval_model="local"
+    )
     assert 0.99 <= metric_value <= 1
 
 
@@ -37,12 +37,13 @@ def test_semantic_similarity_identical(generated_outputs, reference_outputs):
         (["Die KATZE saß auf der MATTE."], ["Die Katze saß auf der Matte."]),
     ],
 )
-def test_semantic_similarity_case_sensitivity(generated_outputs,
-                                              reference_outputs):
+def test_semantic_similarity_case_sensitivity(
+    generated_outputs, reference_outputs
+):
     # nb: the German model is case-sensitive!
-    metric_value = semantic_similarity(generated_outputs,
-                                       reference_outputs,
-                                       eval_model="local")
+    metric_value = semantic_similarity(
+        generated_outputs, reference_outputs, eval_model="local"
+    )
     assert 0.6 <= metric_value <= 0.7
 
 
@@ -54,9 +55,9 @@ def test_semantic_similarity_case_sensitivity(generated_outputs,
     ],
 )
 def test_semantic_similarity_not_similar(generated_outputs, reference_outputs):
-    metric_value = semantic_similarity(generated_outputs,
-                                       reference_outputs,
-                                       eval_model="local")
+    metric_value = semantic_similarity(
+        generated_outputs, reference_outputs, eval_model="local"
+    )
     print(metric_value)
     assert 0.0 <= metric_value <= 0.1
 
@@ -74,14 +75,16 @@ def test_semantic_similarity_openai(generated_outputs, reference_outputs):
 
     # Calling the openai.resources.Embeddings.create method requires an OpenAI
     # API key, so we mock the return value instead
-    with patch("openai.resources.Embeddings.create",
-               Mock(return_value=mock_embedding_response)):
+    with patch(
+        "openai.resources.Embeddings.create",
+        Mock(return_value=mock_embedding_response),
+    ):
         # Set the necessary env vars for the 'openai' embedding model type
         os.environ["OPENAI_API_KEY"] = "dummy_key"
         openai_client = OpenAIEvalClient()
-        metric_value = semantic_similarity(generated_outputs,
-                                           reference_outputs,
-                                           eval_model=openai_client)
+        metric_value = semantic_similarity(
+            generated_outputs, reference_outputs, eval_model=openai_client
+        )
         # Since the mock embeddings are the same for the generated and reference
         # outputs, the semantic similarity should be 1.
         assert 0.99 <= metric_value <= 1
@@ -91,10 +94,11 @@ def test_semantic_similarity_openai(generated_outputs, reference_outputs):
         os.environ["OPENAI_API_VERSION"] = "dummy_version"
         os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
         azure_openai_client = AzureOpenAIEvalClient(
-            embedding_model_name="foo bar")
-        metric_value = semantic_similarity(generated_outputs,
-                                           reference_outputs,
-                                           eval_model=azure_openai_client)
+            embedding_model_name="foo bar"
+        )
+        metric_value = semantic_similarity(
+            generated_outputs, reference_outputs, eval_model=azure_openai_client
+        )
         # Since the mock embeddings are the same for the generated and reference
         # outputs, the semantic similarity should be 1.
         assert 0.99 <= metric_value <= 1

--- a/tests/metrics/de/test_source_based_text_quality.py
+++ b/tests/metrics/de/test_source_based_text_quality.py
@@ -10,14 +10,21 @@ from tests.utils import MockEvalClient
 
 @pytest.mark.parametrize(
     "generated_outputs,sources",
-    [("Tokio ist die Hauptstadt von Japan.",
-      "Tokio ist die Hauptstadt von Japan."),
-     (["Tokio ist die Hauptstadt von Japan.", "Die Erde ist flach."
-      ], ["Tokio ist die Hauptstadt von Japan.", "Die Erde ist rund."])])
+    [
+        (
+            "Tokio ist die Hauptstadt von Japan.",
+            "Tokio ist die Hauptstadt von Japan.",
+        ),
+        (
+            ["Tokio ist die Hauptstadt von Japan.", "Die Erde ist flach."],
+            ["Tokio ist die Hauptstadt von Japan.", "Die Erde ist rund."],
+        ),
+    ],
+)
 def test_factual_consistency(generated_outputs, sources):
-    metric_value = factual_consistency(generated_outputs,
-                                       sources,
-                                       eval_model="local")
+    metric_value = factual_consistency(
+        generated_outputs, sources, eval_model="local"
+    )
     factual_consistency_high = metric_value.metric_values[0]
     assert factual_consistency_high is not None
     assert 0.9 <= factual_consistency_high <= 1
@@ -27,38 +34,54 @@ def test_factual_consistency(generated_outputs, sources):
         assert 0.0 <= factual_consistency_low <= 0.1
 
 
-@pytest.mark.parametrize("generated_outputs,sources",
-                         [("Tokio ist die Hauptstadt von Japan.",
-                           "Tokio ist Japans Hauptstadtstadt."),
-                          (["Tokio ist die Hauptstadt von Japan."
-                           ], ["Tokio ist Japans Hauptstadtstadt."])])
+@pytest.mark.parametrize(
+    "generated_outputs,sources",
+    [
+        (
+            "Tokio ist die Hauptstadt von Japan.",
+            "Tokio ist Japans Hauptstadtstadt.",
+        ),
+        (
+            ["Tokio ist die Hauptstadt von Japan."],
+            ["Tokio ist Japans Hauptstadtstadt."],
+        ),
+    ],
+)
 def test_factual_consistency_eval_client(generated_outputs, sources):
     eval_client = MockEvalClient()
-    metric_value = factual_consistency(generated_outputs,
-                                       sources,
-                                       eval_model=eval_client)
+    metric_value = factual_consistency(
+        generated_outputs, sources, eval_model=eval_client
+    )
     # MockEvalClient without any argument returns None
     assert metric_value.metric_values[0] is None
 
     factual_consistency_assessment_to_score = {
         "Fully Consistent": 1.0,
         "Partially Consistent": 0.5,
-        "Not Consistent": 0.0
+        "Not Consistent": 0.0,
     }
 
     for option in factual_consistency_assessment_to_score:
         eval_client = MockEvalClient(option)
-        metric_value = factual_consistency(generated_outputs,
-                                           sources,
-                                           eval_model=eval_client)
+        metric_value = factual_consistency(
+            generated_outputs, sources, eval_model=eval_client
+        )
         assert metric_value == factual_consistency_assessment_to_score[option]
 
 
-@pytest.mark.parametrize("prompts,sources",
-                         [("Was ist die Hauptstadt von Japan?",
-                           "Tokio ist die Hauptstadtstadt von Japan."),
-                          (["Was ist die Hauptstadt von Japan?"
-                           ], ["Tokio ist die Hauptstadtstadt von Japan."])])
+@pytest.mark.parametrize(
+    "prompts,sources",
+    [
+        (
+            "Was ist die Hauptstadt von Japan?",
+            "Tokio ist die Hauptstadtstadt von Japan.",
+        ),
+        (
+            ["Was ist die Hauptstadt von Japan?"],
+            ["Tokio ist die Hauptstadtstadt von Japan."],
+        ),
+    ],
+)
 def test_context_relevance_eval_client(prompts, sources):
     eval_client = MockEvalClient()
     metric_value = context_relevance(sources, prompts, eval_model=eval_client)
@@ -68,12 +91,12 @@ def test_context_relevance_eval_client(prompts, sources):
     context_relevance_assessment_to_score = {
         "Fully Relevant": 1.0,
         "Partially Relevant": 0.5,
-        "Not Relevant": 0.0
+        "Not Relevant": 0.0,
     }
 
     for option in context_relevance_assessment_to_score:
         eval_client = MockEvalClient(option)
-        metric_value = context_relevance(sources,
-                                         prompts,
-                                         eval_model=eval_client)
+        metric_value = context_relevance(
+            sources, prompts, eval_model=eval_client
+        )
         assert metric_value == context_relevance_assessment_to_score[option]

--- a/tests/metrics/en/test_source_based_text_quality.py
+++ b/tests/metrics/en/test_source_based_text_quality.py
@@ -10,13 +10,18 @@ from tests.utils import MockEvalClient
 
 @pytest.mark.parametrize(
     "generated_outputs,sources",
-    [("Tokyo is the capital of Japan.", "Tokyo is Japan's capital city."),
-     (["Tokyo is the capital of Japan.", "The Earth is flat."
-      ], ["Tokyo is Japan's capital city.", "The Earth is round."])])
+    [
+        ("Tokyo is the capital of Japan.", "Tokyo is Japan's capital city."),
+        (
+            ["Tokyo is the capital of Japan.", "The Earth is flat."],
+            ["Tokyo is Japan's capital city.", "The Earth is round."],
+        ),
+    ],
+)
 def test_factual_consistency(generated_outputs, sources):
-    metric_value = factual_consistency(generated_outputs,
-                                       sources,
-                                       eval_model="local")
+    metric_value = factual_consistency(
+        generated_outputs, sources, eval_model="local"
+    )
     factual_consistency_high = metric_value.metric_values[0]
     assert factual_consistency_high is not None
     assert 0.9 <= factual_consistency_high <= 1
@@ -28,34 +33,43 @@ def test_factual_consistency(generated_outputs, sources):
 
 @pytest.mark.parametrize(
     "generated_outputs,sources",
-    [("Tokyo is the capital of Japan.", "Tokyo is Japan's capital city."),
-     (["Tokyo is the capital of Japan."], ["Tokyo is Japan's capital city."])])
+    [
+        ("Tokyo is the capital of Japan.", "Tokyo is Japan's capital city."),
+        (
+            ["Tokyo is the capital of Japan."],
+            ["Tokyo is Japan's capital city."],
+        ),
+    ],
+)
 def test_factual_consistency_eval_client(generated_outputs, sources):
     eval_client = MockEvalClient()
-    metric_value = factual_consistency(generated_outputs,
-                                       sources,
-                                       eval_model=eval_client)
+    metric_value = factual_consistency(
+        generated_outputs, sources, eval_model=eval_client
+    )
     # MockEvalClient without any argument returns None
     assert metric_value.metric_values[0] is None
 
     factual_consistency_assessment_to_score = {
         "Fully Consistent": 1.0,
         "Partially Consistent": 0.5,
-        "Not Consistent": 0.0
+        "Not Consistent": 0.0,
     }
 
     for option in factual_consistency_assessment_to_score:
         eval_client = MockEvalClient(option)
-        metric_value = factual_consistency(generated_outputs,
-                                           sources,
-                                           eval_model=eval_client)
+        metric_value = factual_consistency(
+            generated_outputs, sources, eval_model=eval_client
+        )
         assert metric_value == factual_consistency_assessment_to_score[option]
 
 
 @pytest.mark.parametrize(
     "prompts,sources",
-    [("What is the capital of Japan?", "Tokyo is Japan's capital city."),
-     (["What is the capital of Japan?"], ["Tokyo is Japan's capital city."])])
+    [
+        ("What is the capital of Japan?", "Tokyo is Japan's capital city."),
+        (["What is the capital of Japan?"], ["Tokyo is Japan's capital city."]),
+    ],
+)
 def test_context_relevance_eval_client(prompts, sources):
     eval_client = MockEvalClient()
     metric_value = context_relevance(sources, prompts, eval_model=eval_client)
@@ -65,12 +79,12 @@ def test_context_relevance_eval_client(prompts, sources):
     context_relevance_assessment_to_score = {
         "Fully Relevant": 1.0,
         "Partially Relevant": 0.5,
-        "Not Relevant": 0.0
+        "Not Relevant": 0.0,
     }
 
     for option in context_relevance_assessment_to_score:
         eval_client = MockEvalClient(option)
-        metric_value = context_relevance(sources,
-                                         prompts,
-                                         eval_model=eval_client)
+        metric_value = context_relevance(
+            sources, prompts, eval_model=eval_client
+        )
         assert metric_value == context_relevance_assessment_to_score[option]

--- a/tests/metrics/eval_clients/test_anthropic.py
+++ b/tests/metrics/eval_clients/test_anthropic.py
@@ -16,9 +16,9 @@ def test_get_text_response_anthropic():
     mock_chat_completion.content = [Mock(text=answer)]
     # Calling the anthropic.resources.Messages.create method requires an
     # Anthropic API key, so we mock the return value instead
-    with patch("anthropic.resources.Messages.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "anthropic.resources.Messages.create", return_value=mock_chat_completion
+    ):
         # Set the necessary env vars for the AnthropicEvalClient
         os.environ["ANTHROPIC_API_KEY"] = "dummy_key"
         client = AnthropicEvalClient()
@@ -41,16 +41,16 @@ def test_get_float_score_anthropic(language):
 
     # Calling the anthropic.resources.Messages.create method requires an
     # Anthropic API key, so we mock the return value instead
-    with patch("anthropic.resources.Messages.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "anthropic.resources.Messages.create", return_value=mock_chat_completion
+    ):
         # Set the necessary env vars for the AnthropicEvalClient
         os.environ["ANTHROPIC_API_KEY"] = "dummy_key"
         client = AnthropicEvalClient()
 
-        scores = client.get_float_score("dummy_metric", language,
-                                        unstructured_assessment_result,
-                                        score_map)
+        scores = client.get_float_score(
+            "dummy_metric", language, unstructured_assessment_result, score_map
+        )
         assert len(scores) == len(unstructured_assessment_result)
         for score in scores:
             assert score == 1.0

--- a/tests/metrics/eval_clients/test_openai.py
+++ b/tests/metrics/eval_clients/test_openai.py
@@ -20,9 +20,10 @@ def test_get_text_response_openai():
     mock_chat_completion.choices = [Mock(message=Mock(content=answer))]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the OpenAIEValClient
         os.environ["OPENAI_API_KEY"] = "dummy_key"
         client = OpenAIEvalClient()
@@ -42,21 +43,29 @@ def test_get_float_score_openai(language):
 
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [
-        Mock(message=Mock(function_call=Mock(
-            arguments=json.dumps({"assessment": short_assessment_result}))))
+        Mock(
+            message=Mock(
+                function_call=Mock(
+                    arguments=json.dumps(
+                        {"assessment": short_assessment_result}
+                    )
+                )
+            )
+        )
     ]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the OpenAIEValClient
         os.environ["OPENAI_API_KEY"] = "dummy_key"
         client = OpenAIEvalClient()
 
-        scores = client.get_float_score("dummy_metric", language,
-                                        unstructured_assessment_result,
-                                        score_map)
+        scores = client.get_float_score(
+            "dummy_metric", language, unstructured_assessment_result, score_map
+        )
         assert len(scores) == len(unstructured_assessment_result)
         for score in scores:
             assert score == 1.0
@@ -69,9 +78,10 @@ def test_get_text_response_azure_openai():
     mock_chat_completion.choices = [Mock(message=Mock(content=answer))]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the 'azure_openai' model type
         os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
         os.environ["OPENAI_API_VERSION"] = "dummy_version"
@@ -93,23 +103,31 @@ def test_get_float_score_azure_openai():
 
     mock_chat_completion = Mock(spec=ChatCompletion)
     mock_chat_completion.choices = [
-        Mock(message=Mock(function_call=Mock(
-            arguments=json.dumps({"assessment": short_assessment_result}))))
+        Mock(
+            message=Mock(
+                function_call=Mock(
+                    arguments=json.dumps(
+                        {"assessment": short_assessment_result}
+                    )
+                )
+            )
+        )
     ]
     # Calling the openai.resources.chat.Completions.create method requires an
     # OpenAI API key, so we mock the return value instead
-    with patch("openai.resources.chat.Completions.create",
-               return_value=mock_chat_completion):
-
+    with patch(
+        "openai.resources.chat.Completions.create",
+        return_value=mock_chat_completion,
+    ):
         # Set the necessary env vars for the 'azure_openai' model type
         os.environ["AZURE_OPENAI_KEY"] = "dummy_azure_key"
         os.environ["OPENAI_API_VERSION"] = "dummy_version"
         os.environ["AZURE_OPENAI_ENDPOINT"] = "dummy_endpoint"
         client = AzureOpenAIEvalClient(text_model_name="foo bar")
 
-        scores = client.get_float_score("dummy_metric", "en",
-                                        unstructured_assessment_result,
-                                        score_map)
+        scores = client.get_float_score(
+            "dummy_metric", "en", unstructured_assessment_result, score_map
+        )
         assert len(scores) == len(unstructured_assessment_result)
         for score in scores:
             assert score == 1.0

--- a/tests/metrics/eval_clients/test_openrouter.py
+++ b/tests/metrics/eval_clients/test_openrouter.py
@@ -12,16 +12,12 @@ from langcheck.metrics.eval_clients import OpenRouterEvalClient
 def test_get_text_response_openrouter(system_prompt):
     prompts = ["Assess the factual consistency of the generated output..."] * 2
     answer = "The output is fully factually consistent."
-    mock_response = [{
-        "choices": [
-            {"message": {"content": answer}}
-        ]
-    }] * 2
+    mock_response = [{"choices": [{"message": {"content": answer}}]}] * 2
     # Calling the _call_api method requires an
     # OpenRouter API key, so we mock the return value instead
     with patch(
-            "langcheck.metrics.eval_clients.OpenRouterEvalClient._call_api",
-            return_value=mock_response
+        "langcheck.metrics.eval_clients.OpenRouterEvalClient._call_api",
+        return_value=mock_response,
     ):
         # Set the necessary env vars for the OpenRouterEvalClient
         os.environ["OPENROUTER_API_KEY"] = "dummy_key"
@@ -30,6 +26,7 @@ def test_get_text_response_openrouter(system_prompt):
         assert len(responses) == len(prompts)
         for response in responses:
             assert response == answer
+
 
 @pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
 @pytest.mark.parametrize("language", ["en", "ja"])
@@ -40,17 +37,14 @@ def test_get_float_score_openrouter(system_prompt, language):
     short_assessment_result = "Fully Consistent"
     score_map = {short_assessment_result: 1.0}
 
-    mock_response = [{
-        "choices": [
-            {"message": {"content": short_assessment_result}}
-        ]
-    }] * 2
+    mock_response = [
+        {"choices": [{"message": {"content": short_assessment_result}}]}
+    ] * 2
 
     with patch(
-            "langcheck.metrics.eval_clients.OpenRouterEvalClient._call_api",
-            return_value=mock_response
+        "langcheck.metrics.eval_clients.OpenRouterEvalClient._call_api",
+        return_value=mock_response,
     ):
-
         # Set the necessary env vars for the OpenRouterEvalClient
         os.environ["OPENROUTER_API_KEY"] = "dummy_key"
         client = OpenRouterEvalClient(system_prompt=system_prompt)

--- a/tests/metrics/ja/test_source_based_text_quality.py
+++ b/tests/metrics/ja/test_source_based_text_quality.py
@@ -10,8 +10,14 @@ from tests.utils import MockEvalClient
 
 @pytest.mark.parametrize(
     "generated_outputs,sources",
-    [("東京は日本の首都です。", "東京は日本の首都です。"),
-     (["東京は日本の首都です。", "地球は平面です。"], ["東京は日本の首都です。", "地球は球体です。"])])
+    [
+        ("東京は日本の首都です。", "東京は日本の首都です。"),
+        (
+            ["東京は日本の首都です。", "地球は平面です。"],
+            ["東京は日本の首都です。", "地球は球体です。"],
+        ),
+    ],
+)
 def test_factual_consistency(generated_outputs, sources):
     metric_value = factual_consistency(generated_outputs, sources)
     factual_consistency_high = metric_value.metric_values[0]
@@ -23,34 +29,42 @@ def test_factual_consistency(generated_outputs, sources):
         assert 0.0 <= factual_consistency_low <= 0.1
 
 
-@pytest.mark.parametrize("generated_outputs,sources",
-                         [("東京は日本の首都です。", "東京は日本の首都です。"),
-                          (["東京は日本の首都です。"], ["東京は日本の首都です。"])])
+@pytest.mark.parametrize(
+    "generated_outputs,sources",
+    [
+        ("東京は日本の首都です。", "東京は日本の首都です。"),
+        (["東京は日本の首都です。"], ["東京は日本の首都です。"]),
+    ],
+)
 def test_factual_consistency_eval_client(generated_outputs, sources):
     eval_client = MockEvalClient()
-    metric_value = factual_consistency(generated_outputs,
-                                       sources,
-                                       eval_model=eval_client)
+    metric_value = factual_consistency(
+        generated_outputs, sources, eval_model=eval_client
+    )
     # MockEvalClient without any argument returns None
     assert metric_value.metric_values[0] is None
 
     factual_consistency_assessment_to_score = {
         "Fully Consistent": 1.0,
         "Partially Consistent": 0.5,
-        "Not Consistent": 0.0
+        "Not Consistent": 0.0,
     }
 
     for option in factual_consistency_assessment_to_score:
         eval_client = MockEvalClient(option)
-        metric_value = factual_consistency(generated_outputs,
-                                           sources,
-                                           eval_model=eval_client)
+        metric_value = factual_consistency(
+            generated_outputs, sources, eval_model=eval_client
+        )
         assert metric_value == factual_consistency_assessment_to_score[option]
 
 
-@pytest.mark.parametrize("prompts,sources",
-                         [("日本の首都は何ですか？", "東京は日本の首都です。"),
-                          (["日本の首都は何ですか？"], ["東京は日本の首都です。"])])
+@pytest.mark.parametrize(
+    "prompts,sources",
+    [
+        ("日本の首都は何ですか？", "東京は日本の首都です。"),
+        (["日本の首都は何ですか？"], ["東京は日本の首都です。"]),
+    ],
+)
 def test_context_relevance_eval_client(prompts, sources):
     eval_client = MockEvalClient()
     metric_value = context_relevance(sources, prompts, eval_model=eval_client)
@@ -60,12 +74,12 @@ def test_context_relevance_eval_client(prompts, sources):
     context_relevance_assessment_to_score = {
         "Fully Relevant": 1.0,
         "Partially Relevant": 0.5,
-        "Not Relevant": 0.0
+        "Not Relevant": 0.0,
     }
 
     for option in context_relevance_assessment_to_score:
         eval_client = MockEvalClient(option)
-        metric_value = context_relevance(sources,
-                                         prompts,
-                                         eval_model=eval_client)
+        metric_value = context_relevance(
+            sources, prompts, eval_model=eval_client
+        )
         assert metric_value == context_relevance_assessment_to_score[option]

--- a/tests/metrics/model_manager/test_model_loader.py
+++ b/tests/metrics/model_manager/test_model_loader.py
@@ -21,70 +21,102 @@ MockSentenceTransModel = MagicMock(spec=SentenceTransformer)
 MockSeqClassificationModel = MagicMock(spec=AutoModelForSequenceClassification)
 
 
-@pytest.mark.parametrize("model_name,tokenizer_name,revision",
-                         [("t5-small", None, "main"),
-                          ("t5-small", "t5-base", "main")])
+@pytest.mark.parametrize(
+    "model_name,tokenizer_name,revision",
+    [("t5-small", None, "main"), ("t5-small", "t5-base", "main")],
+)
 def test_load_auto_model_for_seq2seq(model_name, tokenizer_name, revision):
-    with patch("transformers.AutoTokenizer.from_pretrained",
-               return_value=MockTokenizer) as mock_tokenizer, \
-         patch("transformers.AutoModelForSeq2SeqLM.from_pretrained",
-               return_value=MockSeq2SeqModel) as mock_model:
+    with (
+        patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=MockTokenizer,
+        ) as mock_tokenizer,
+        patch(
+            "transformers.AutoModelForSeq2SeqLM.from_pretrained",
+            return_value=MockSeq2SeqModel,
+        ) as mock_model,
+    ):
         tokenizer, model = load_auto_model_for_seq2seq(
             model_name=model_name,
             tokenizer_name=tokenizer_name,
             model_revision=revision,
-            tokenizer_revision=revision)
+            tokenizer_revision=revision,
+        )
         if tokenizer_name is None:
             tokenizer_name = model_name
 
         mock_model.assert_called_once()
         mock_tokenizer.assert_called_once()
         # Assert that the returned objects are instances of the mocked objects
-        assert tokenizer == MockTokenizer, \
+        assert tokenizer == MockTokenizer, (
             "The returned tokenizer is not the expected mock object"
-        assert model == MockSeq2SeqModel, \
+        )
+        assert model == MockSeq2SeqModel, (
             "The returned model is not the expected mock object"
+        )
 
 
-@pytest.mark.parametrize("model_name,tokenizer_name,revision",
-                         [("bert-base-uncased", None, "main"),
-                          ("bert-base-uncased", "bert-large-uncased", "main")])
-def test_load_auto_model_for_text_classification(model_name, tokenizer_name,
-                                                 revision):
-    with patch("transformers.AutoTokenizer.from_pretrained",
-               return_value=MockTokenizer) as mock_tokenizer, \
-         patch("transformers.AutoModelForSequenceClassification.from_pretrained",  # NOQA:E501
-               return_value=MockSeqClassificationModel) as mock_model:
+@pytest.mark.parametrize(
+    "model_name,tokenizer_name,revision",
+    [
+        ("bert-base-uncased", None, "main"),
+        ("bert-base-uncased", "bert-large-uncased", "main"),
+    ],
+)
+def test_load_auto_model_for_text_classification(
+    model_name, tokenizer_name, revision
+):
+    with (
+        patch(
+            "transformers.AutoTokenizer.from_pretrained",
+            return_value=MockTokenizer,
+        ) as mock_tokenizer,
+        patch(
+            "transformers.AutoModelForSequenceClassification.from_pretrained",  # NOQA:E501
+            return_value=MockSeqClassificationModel,
+        ) as mock_model,
+    ):
         tokenizer, model = load_auto_model_for_text_classification(
             model_name=model_name,
             tokenizer_name=tokenizer_name,
             model_revision=revision,
-            tokenizer_revision=revision)
+            tokenizer_revision=revision,
+        )
         if tokenizer_name is None:
             tokenizer_name = model_name
 
         mock_model.assert_called_once()
         mock_tokenizer.assert_called_once()
         # Assert that the returned objects are instances of the mocked objects
-        assert tokenizer == MockTokenizer, \
+        assert tokenizer == MockTokenizer, (
             "The returned tokenizer is not the expected mock object"
-        assert model == MockSeqClassificationModel, \
+        )
+        assert model == MockSeqClassificationModel, (
             "The returned model is not the expected mock object"
+        )
 
 
-@pytest.mark.parametrize("model_name,tokenizer_name,revision",
-                         [("all-MiniLM-L6-v2", None, "main"),
-                          ("all-MiniLM-L6-v2", "all-mpnet-base-v2", "main")])
+@pytest.mark.parametrize(
+    "model_name,tokenizer_name,revision",
+    [
+        ("all-MiniLM-L6-v2", None, "main"),
+        ("all-MiniLM-L6-v2", "all-mpnet-base-v2", "main"),
+    ],
+)
 def test_load_sentence_transformers(model_name, tokenizer_name, revision):
-    with patch.object(SentenceTransformer, "__init__",
-                      return_value=None) as mock_init:
-        model = load_sentence_transformers(model_name=model_name,
-                                           tokenizer_name=tokenizer_name,
-                                           model_revision=revision,
-                                           tokenizer_revision=revision)
+    with patch.object(
+        SentenceTransformer, "__init__", return_value=None
+    ) as mock_init:
+        model = load_sentence_transformers(
+            model_name=model_name,
+            tokenizer_name=tokenizer_name,
+            model_revision=revision,
+            tokenizer_revision=revision,
+        )
         # Check if the model was loaded correctly
         mock_init.assert_called_once_with(model_name)
 
         # Assert that the returned objects are instances of the mocked objects
-        assert isinstance(model, SentenceTransformer), \
+        assert isinstance(model, SentenceTransformer), (
             "The returned model is not the expected mock object"
+        )

--- a/tests/metrics/model_manager/test_model_manager.py
+++ b/tests/metrics/model_manager/test_model_manager.py
@@ -54,24 +54,36 @@ def mock_model_manager(temp_config_path):
     Returns:
         The mock ModelManager.
     """
-    with patch("os.path.join", return_value=temp_config_path), \
-         patch("langcheck.metrics.model_manager._model_management.check_model_availability",  # NOQA:E501
-               return_value=True), \
-         patch.object(_model_management, "VALID_LANGUAGE", ["ja", "zh"]):
+    with (
+        patch("os.path.join", return_value=temp_config_path),
+        patch(
+            "langcheck.metrics.model_manager._model_management.check_model_availability",  # NOQA:E501
+            return_value=True,
+        ),
+        patch.object(_model_management, "VALID_LANGUAGE", ["ja", "zh"]),
+    ):
         model_manager = ModelManager()
         return model_manager
 
 
 @pytest.mark.parametrize(
     "model_name,revision, status_code",
-    [("bert-base-uncased", "", "200"), ("bert-base-uncased", None, "200"),
-     ("bert-base-uncased", "main", "200"),
-     ("bert-base-uncased", "a265f77", "200"),
-     ("bert-base-uncased", "a265f773a47193eed794233aa2a0f0bb6d3eaa63", "200"),
-     pytest.param(
-         "bert-base-uncased", "a265f78", "404", marks=pytest.mark.xfail),
-     pytest.param("", "0e9f4", "404", marks=pytest.mark.xfail),
-     pytest.param("terb-base-uncased", "", "404", marks=pytest.mark.xfail)],
+    [
+        ("bert-base-uncased", "", "200"),
+        ("bert-base-uncased", None, "200"),
+        ("bert-base-uncased", "main", "200"),
+        ("bert-base-uncased", "a265f77", "200"),
+        (
+            "bert-base-uncased",
+            "a265f773a47193eed794233aa2a0f0bb6d3eaa63",
+            "200",
+        ),
+        pytest.param(
+            "bert-base-uncased", "a265f78", "404", marks=pytest.mark.xfail
+        ),
+        pytest.param("", "0e9f4", "404", marks=pytest.mark.xfail),
+        pytest.param("terb-base-uncased", "", "404", marks=pytest.mark.xfail),
+    ],
 )
 @patch("requests.get")
 def test_check_model_availability(mock_get, model_name, revision, status_code):
@@ -83,29 +95,43 @@ def test_check_model_availability(mock_get, model_name, revision, status_code):
 def test_model_manager_initiation(mock_model_manager):
     mock_config = mock_model_manager.config
     assert "toxicity" in mock_config["zh"]
-    assert mock_config["zh"]["toxicity"]["model_name"] == \
-        "alibaba-pai/pai-bert-base-zh-llm-risk-detection"
-    assert mock_config["zh"]["toxicity"]["loader_func"] == \
-        "load_auto_model_for_text_classification"
+    assert (
+        mock_config["zh"]["toxicity"]["model_name"]
+        == "alibaba-pai/pai-bert-base-zh-llm-risk-detection"
+    )
+    assert (
+        mock_config["zh"]["toxicity"]["loader_func"]
+        == "load_auto_model_for_text_classification"
+    )
 
     assert "toxicity" in mock_config["ja"]
-    assert mock_config["ja"]["toxicity"]["model_name"] ==\
-        "Alnusjaponica/toxicity-score-multi-classification"
-    assert mock_config["ja"]["toxicity"]["model_revision"] ==\
-        "bc7a465029744889c8252ee858ab04ab9efdb0e7"
-    assert mock_config["ja"]["toxicity"]["tokenizer_name"] ==\
-        "line-corporation/line-distilbert-base-japanese"
-    assert mock_config["ja"]["toxicity"]["tokenizer_revision"] ==\
-        "93bd4811608eecb95ffaaba957646efd9a909cc8"
-    assert mock_config["ja"]["toxicity"]["loader_func"] ==\
-        "load_auto_model_for_text_classification"
+    assert (
+        mock_config["ja"]["toxicity"]["model_name"]
+        == "Alnusjaponica/toxicity-score-multi-classification"
+    )
+    assert (
+        mock_config["ja"]["toxicity"]["model_revision"]
+        == "bc7a465029744889c8252ee858ab04ab9efdb0e7"
+    )
+    assert (
+        mock_config["ja"]["toxicity"]["tokenizer_name"]
+        == "line-corporation/line-distilbert-base-japanese"
+    )
+    assert (
+        mock_config["ja"]["toxicity"]["tokenizer_revision"]
+        == "93bd4811608eecb95ffaaba957646efd9a909cc8"
+    )
+    assert (
+        mock_config["ja"]["toxicity"]["loader_func"]
+        == "load_auto_model_for_text_classification"
+    )
 
 
 def test_model_manager_fetch_model(mock_model_manager):
-    with \
-        patch.dict(
-            "langcheck.metrics.model_manager._model_management.LOADER_MAP",
-            {"load_auto_model_for_text_classification": MagicMock()}):
+    with patch.dict(
+        "langcheck.metrics.model_manager._model_management.LOADER_MAP",
+        {"load_auto_model_for_text_classification": MagicMock()},
+    ):
         model = mock_model_manager.fetch_model(language="zh", metric="toxicity")
         assert model is not None
         model = mock_model_manager.fetch_model(language="ja", metric="toxicity")

--- a/tests/metrics/test_reference_based_text_quality.py
+++ b/tests/metrics/test_reference_based_text_quality.py
@@ -9,8 +9,11 @@ from langcheck.metrics import exact_match
 
 @pytest.mark.parametrize(
     "generated_outputs,reference_outputs",
-    [("The cat sat on the mat.", "The cat sat on the mat."),
-     (["The cat sat on the mat."], ["The cat sat on the mat."])])
+    [
+        ("The cat sat on the mat.", "The cat sat on the mat."),
+        (["The cat sat on the mat."], ["The cat sat on the mat."]),
+    ],
+)
 def test_exact_match(generated_outputs, reference_outputs):
     metric_value = exact_match(generated_outputs, reference_outputs)
     assert metric_value == 1
@@ -18,8 +21,11 @@ def test_exact_match(generated_outputs, reference_outputs):
 
 @pytest.mark.parametrize(
     "generated_outputs,reference_outputs",
-    [("The CAT sat on the MAT.", "The cat sat on the mat."),
-     (["The CAT sat on the MAT."], ["The cat sat on the mat."])])
+    [
+        ("The CAT sat on the MAT.", "The cat sat on the mat."),
+        (["The CAT sat on the MAT."], ["The cat sat on the mat."]),
+    ],
+)
 def test_not_exact_match(generated_outputs, reference_outputs):
     metric_value = exact_match(generated_outputs, reference_outputs)
     assert metric_value == 0

--- a/tests/metrics/test_text_structure.py
+++ b/tests/metrics/test_text_structure.py
@@ -29,8 +29,14 @@ from tests.utils import is_close, lists_are_equal
         (["-100", "-1", "0", "1", "100"], {0, 1, 2}, [0, 0, 1, 1, 0]),
         (
             [
-                "lorem", "ipsum", "13.14", "-999.999", "true", "True", "false",
-                "False"
+                "lorem",
+                "ipsum",
+                "13.14",
+                "-999.999",
+                "true",
+                "True",
+                "false",
+                "False",
             ],
             None,
             [0, 0, 0, 0, 0, 0, 0, 0],
@@ -57,8 +63,14 @@ def test_is_int(generated_outputs, domain, metric_values):
         (["-100.5", "-1", "0", "1", "100.5"], -5, 5, [0, 1, 1, 1, 0]),
         (
             [
-                "lorem", "ipsum", "13.14", "-999.999", "true", "True", "false",
-                "False"
+                "lorem",
+                "ipsum",
+                "13.14",
+                "-999.999",
+                "true",
+                "True",
+                "false",
+                "False",
             ],
             None,
             None,
@@ -76,19 +88,22 @@ def test_is_float(generated_outputs, min, max, metric_values):
     assert is_close(metric_value.metric_values, metric_values)
 
 
-@pytest.mark.parametrize("generated_outputs,metric_values", [
-    ("""[1, 2, 3]""", [1]),
-    (["""[1, 2, 3]"""], [1]),
-    (["""["lorem", 1.5, -123.456, {"foo": 9999}, [1, 2, 3]]"""], [1]),
-    (["""[1, 2, 3"""], [0]),
-    (["""1, 2, 3]"""], [0]),
-    (["""1, 2, 3"""], [0]),
-    (["""[1, 2, 3]]"""], [0]),
-    (["""[[1, 2, 3]"""], [0]),
-    (['''"foo"'''], [0]),
-    (["""1"""], [0]),
-    (["""{"a": 1, "b": 2.5}"""], [0]),
-])
+@pytest.mark.parametrize(
+    "generated_outputs,metric_values",
+    [
+        ("""[1, 2, 3]""", [1]),
+        (["""[1, 2, 3]"""], [1]),
+        (["""["lorem", 1.5, -123.456, {"foo": 9999}, [1, 2, 3]]"""], [1]),
+        (["""[1, 2, 3"""], [0]),
+        (["""1, 2, 3]"""], [0]),
+        (["""1, 2, 3"""], [0]),
+        (["""[1, 2, 3]]"""], [0]),
+        (["""[[1, 2, 3]"""], [0]),
+        (['''"foo"'''], [0]),
+        (["""1"""], [0]),
+        (["""{"a": 1, "b": 2.5}"""], [0]),
+    ],
+)
 def test_is_json_array(generated_outputs, metric_values):
     metric_value = is_json_array(generated_outputs)
     assert metric_value.metric_name == "is_json_array"
@@ -99,19 +114,22 @@ def test_is_json_array(generated_outputs, metric_values):
     assert is_close(metric_value.metric_values, metric_values)
 
 
-@pytest.mark.parametrize("generated_outputs,metric_values", [
-    ("""{"a": 1, "b": 2.5}""", [1]),
-    (["""{"a": 1, "b": 2.5}"""], [1]),
-    (["""{"a": "foo", "b": -9999, "c": {"d": "e"}, "f": [1]}"""], [1]),
-    ([""""a": 1, "b": 2.5}"""], [0]),
-    (["""{"a": 1, "b": 2.5"""], [0]),
-    ([""""a": 1, "b": 2.5"""], [0]),
-    (["""{"a": 1, "b": 2.5}}"""], [0]),
-    (["""{{"a": 1, "b": 2.5}"""], [0]),
-    (['''"foo"'''], [0]),
-    (["""1"""], [0]),
-    (["""[1, 2, 3]"""], [0]),
-])
+@pytest.mark.parametrize(
+    "generated_outputs,metric_values",
+    [
+        ("""{"a": 1, "b": 2.5}""", [1]),
+        (["""{"a": 1, "b": 2.5}"""], [1]),
+        (["""{"a": "foo", "b": -9999, "c": {"d": "e"}, "f": [1]}"""], [1]),
+        ([""""a": 1, "b": 2.5}"""], [0]),
+        (["""{"a": 1, "b": 2.5"""], [0]),
+        ([""""a": 1, "b": 2.5"""], [0]),
+        (["""{"a": 1, "b": 2.5}}"""], [0]),
+        (["""{{"a": 1, "b": 2.5}"""], [0]),
+        (['''"foo"'''], [0]),
+        (["""1"""], [0]),
+        (["""[1, 2, 3]"""], [0]),
+    ],
+)
 def test_is_json_object(generated_outputs, metric_values):
     metric_value = is_json_object(generated_outputs)
     assert metric_value.metric_name == "is_json_object"
@@ -223,10 +241,12 @@ def test_contains_regex(generated_outputs, regex, metric_values):
         ),
     ],
 )
-def test_contains_all_strings(generated_outputs, strings, case_sensitive,
-                              metric_values):
-    metric_value = contains_all_strings(generated_outputs, strings,
-                                        case_sensitive)
+def test_contains_all_strings(
+    generated_outputs, strings, case_sensitive, metric_values
+):
+    metric_value = contains_all_strings(
+        generated_outputs, strings, case_sensitive
+    )
     assert metric_value.metric_name == "contains_all_strings"
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
@@ -270,10 +290,12 @@ def test_contains_all_strings(generated_outputs, strings, case_sensitive,
         ),
     ],
 )
-def test_contains_any_strings(generated_outputs, strings, case_sensitive,
-                              metric_values):
-    metric_value = contains_any_strings(generated_outputs, strings,
-                                        case_sensitive)
+def test_contains_any_strings(
+    generated_outputs, strings, case_sensitive, metric_values
+):
+    metric_value = contains_any_strings(
+        generated_outputs, strings, case_sensitive
+    )
     assert metric_value.metric_name == "contains_any_strings"
     assert metric_value.prompts is None
     assert metric_value.generated_outputs is not None
@@ -282,14 +304,17 @@ def test_contains_any_strings(generated_outputs, strings, case_sensitive,
     assert is_close(metric_value.metric_values, metric_values)
 
 
-@pytest.mark.parametrize("generated_outputs,valid_fn,metric_values", [
-    ("2", lambda x: int(x) % 2 == 0, [1]),
-    (["2", "4", "9", "11"], lambda x: int(x) % 2 == 0, [1, 1, 0, 0]),
-    (["""{"myKey": 123}"""], lambda x: "myKey" in json.loads(x), [1]),
-    (["""{"foo": 123}"""], lambda x: "myKey" in json.loads(x), [0]),
-    ([""""myKey": 123"""], lambda x: "myKey" in json.loads(x), [0]),
-    (["lorem ipsum"], lambda x: x / 0, [0]),
-])
+@pytest.mark.parametrize(
+    "generated_outputs,valid_fn,metric_values",
+    [
+        ("2", lambda x: int(x) % 2 == 0, [1]),
+        (["2", "4", "9", "11"], lambda x: int(x) % 2 == 0, [1, 1, 0, 0]),
+        (["""{"myKey": 123}"""], lambda x: "myKey" in json.loads(x), [1]),
+        (["""{"foo": 123}"""], lambda x: "myKey" in json.loads(x), [0]),
+        ([""""myKey": 123"""], lambda x: "myKey" in json.loads(x), [0]),
+        (["lorem ipsum"], lambda x: x / 0, [0]),
+    ],
+)
 def test_validation_fn(generated_outputs, valid_fn, metric_values):
     metric_value = validation_fn(generated_outputs, valid_fn)
     assert metric_value.metric_name == "validation_fn"

--- a/tests/metrics/zh/test_source_based_text_quality.py
+++ b/tests/metrics/zh/test_source_based_text_quality.py
@@ -8,11 +8,21 @@ from tests.utils import MockEvalClient
 ################################################################################
 
 
-@pytest.mark.parametrize("generated_outputs,sources", [
-    ("北京是中国的首都。", "中国的首都是北京"),
-    pytest.param("地球围绕着太阳转动。", "太阳是太阳系的中心。", marks=pytest.mark.xfail),
-    pytest.param(["飞机在是一种空中交通工具。", "太阳围绕着地球转动。"], ["飞机在可以在天上飞。", "太阳是太阳系的中心。"]),
-])
+@pytest.mark.parametrize(
+    "generated_outputs,sources",
+    [
+        ("北京是中国的首都。", "中国的首都是北京"),
+        pytest.param(
+            "地球围绕着太阳转动。",
+            "太阳是太阳系的中心。",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            ["飞机在是一种空中交通工具。", "太阳围绕着地球转动。"],
+            ["飞机在可以在天上飞。", "太阳是太阳系的中心。"],
+        ),
+    ],
+)
 def test_factual_consistency(generated_outputs, sources):
     metric_value = factual_consistency(generated_outputs, sources)
     factual_consistency_high = metric_value.metric_values[0]
@@ -24,26 +34,30 @@ def test_factual_consistency(generated_outputs, sources):
         assert 0.0 <= factual_consistency_low <= 0.1
 
 
-@pytest.mark.parametrize("generated_outputs,sources",
-                         [("北京是中国的首都。", "中国的首都是北京"),
-                          (["北京是中国的首都。"], ["中国的首都是北京"])])
+@pytest.mark.parametrize(
+    "generated_outputs,sources",
+    [
+        ("北京是中国的首都。", "中国的首都是北京"),
+        (["北京是中国的首都。"], ["中国的首都是北京"]),
+    ],
+)
 def test_factual_consistency_eval_client(generated_outputs, sources):
     eval_client = MockEvalClient()
-    metric_value = factual_consistency(generated_outputs,
-                                       sources,
-                                       eval_model=eval_client)
+    metric_value = factual_consistency(
+        generated_outputs, sources, eval_model=eval_client
+    )
     # MockEvalClient without any argument returns None
     assert metric_value.metric_values[0] is None
 
     factual_consistency_assessment_to_score = {
         "Fully Consistent": 1.0,
         "Partially Consistent": 0.5,
-        "Not Consistent": 0.0
+        "Not Consistent": 0.0,
     }
 
     for option in factual_consistency_assessment_to_score:
         eval_client = MockEvalClient(option)
-        metric_value = factual_consistency(generated_outputs,
-                                           sources,
-                                           eval_model=eval_client)
+        metric_value = factual_consistency(
+            generated_outputs, sources, eval_model=eval_client
+        )
         assert metric_value == factual_consistency_assessment_to_score[option]

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -6,18 +6,14 @@ import pytest
 from langcheck.utils import load_json
 
 
-@pytest.mark.parametrize("json_data", [["a", "b", "c", 1, 2, 3], {
-    "a": 1,
-    "b": 2,
-    "c": 3
-}, {
-    "a": 123,
-    "b": 456,
-    "c": [1, 2, 3],
-    "d": {
-        "e": 789
-    }
-}])
+@pytest.mark.parametrize(
+    "json_data",
+    [
+        ["a", "b", "c", 1, 2, 3],
+        {"a": 1, "b": 2, "c": 3},
+        {"a": 123, "b": 456, "c": [1, 2, 3], "d": {"e": 789}},
+    ],
+)
 def test_load_json(json_data):
     # Save to JSON file in /tmp
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as f:


### PR DESCRIPTION
Several files are left unformatted so I added `ruff format --check` to the format CI.
Also, we were running `ruff format src/ tests/` not to format some `.ipynb` files. Instead I explicitly excluded `docs/` so that we can simply run `ruff format/check` in the project root. 