### PR TITLE
Add use_async to GeminiEvalClient

### DIFF
--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -85,7 +85,7 @@ class GeminiEvalClient(EvalClient):
                     *map(
                         lambda prompt: self.client.aio.models.generate_content(
                             model=model,
-                            contents=prompt,
+                            contents=types.Part.from_text(text=prompt),
                             config=types.GenerateContentConfig(**config),
                         ),
                         prompts,
@@ -104,7 +104,7 @@ class GeminiEvalClient(EvalClient):
                 try:
                     return self.client.models.generate_content(
                         model=model,
-                        contents=prompt,
+                        contents=types.Part.from_text(text=prompt),
                         config=types.GenerateContentConfig(**config),
                     )
                 except Exception as e:
@@ -303,7 +303,9 @@ class GeminiSimilarityScorer(BaseSimilarityScorer):
             async def _call_async_api():
                 embed_response = await self._client.aio.models.embed_content(
                     model=self._embed_model_name,
-                    contents=inputs,  # type: ignore
+                    contents=[
+                        types.Part.from_text(text=prompt) for prompt in inputs
+                    ],
                 )
                 return embed_response
 
@@ -312,7 +314,9 @@ class GeminiSimilarityScorer(BaseSimilarityScorer):
         else:
             embed_response = self._client.models.embed_content(
                 model=self._embed_model_name,
-                contents=inputs,  # type: ignore
+                contents=[
+                    types.Part.from_text(text=prompt) for prompt in inputs
+                ],
             )
 
         assert embed_response.embeddings is not None

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -31,11 +31,13 @@ class GeminiEvalClient(EvalClient):
         Initialize the Gemini evaluation client. The authentication
         information is automatically read from the environment variables,
         so please make sure GOOGLE_API_KEY is set.
+        If you want to use Vertex AI, please set the following environment
+        variables appropriately:
+        - GOOGLE_CLOUD_PROJECT=<your-project-id>
+        - GOOGLE_CLOUD_LOCATION=<location>
+        - GOOGLE_GENAI_USE_VERTEXAI=true
 
-        TODO: Allow the user to specify the use of async.
-        https://github.com/citadel-ai/langcheck/issues/191
-
-        Ref:
+        References:
             https://ai.google.dev/api/python/google/generativeai/GenerativeModel
 
         Args:


### PR DESCRIPTION
Resolves #191 

The new Gemini SDK handles async API, so this PR introduces that into GeminiEvalClient.

```Python
import time

from dotenv import load_dotenv

from langcheck.metrics.eval_clients._gemini import GeminiEvalClient

load_dotenv()

client = GeminiEvalClient()
async_client = GeminiEvalClient(use_async=True)

prompts = ["Hello"] * 10

# get_text_responses test
start_time = time.time()
client.get_text_responses(prompts=prompts)
end_time = time.time()
print(f"Time (sync): {end_time - start_time} seconds")

start_time = time.time()
async_client.get_text_responses(prompts=prompts)
end_time = time.time()
print(f"Time (async): {end_time - start_time} seconds")

scorer = client.similarity_scorer()
async_scorer = async_client.similarity_scorer()

# _embed test
start_time = time.time()
scorer._embed(inputs=prompts).shape
end_time = time.time()
print(f"Time (sync): {end_time - start_time} seconds")

start_time = time.time()
scorer._embed(inputs=prompts).shape
end_time = time.time()
print(f"Time (async): {end_time - start_time} seconds")

```

```bash
Intermediate assessments (1/2): 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:12<00:00,  1.20s/it]
Time (sync): 8.539611577987671 seconds
Time (async): 2.018961191177368 seconds
Time (sync): 1.5758183002471924 seconds
Time (async): 0.42234373092651367 seconds
```