### PR TITLE
Add explicit arguments for Vertex AI eval clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.10.0.dev2"
+version = "0.10.0.dev3"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ requires-python = ">=3.9"
 de = []  # No extra dependencies needed for German
 en = []  # English support is installed by default
 ja = [
-    'chikkarpy',
+    'chikkarpy >= 0.1.1',  # See https://github.com/WorksApplications/chikkarpy/issues/8
     'fugashi',  # For tokenizer of metrics.ja.toxicity()
     'janome >= 0.3.1',
     'unidic-lite >= 1.0.1'  # For tokenizer of metrics.ja.toxicity()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.10.0.dev3"
+version = "0.10.0.dev2"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]

--- a/src/langcheck/__init__.py
+++ b/src/langcheck/__init__.py
@@ -1,4 +1,4 @@
 from langcheck import augment, metrics, plot, utils
 
 __all__ = ["augment", "metrics", "plot", "utils"]
-__version__ = "0.10.0.dev2"
+__version__ = "0.10.0.dev3"

--- a/src/langcheck/__init__.py
+++ b/src/langcheck/__init__.py
@@ -1,4 +1,4 @@
 from langcheck import augment, metrics, plot, utils
 
 __all__ = ["augment", "metrics", "plot", "utils"]
-__version__ = "0.10.0.dev3"
+__version__ = "0.10.0.dev2"

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -33,8 +33,8 @@ class AnthropicEvalClient(EvalClient):
         Initialize the Anthropic evaluation client. The authentication
         information is automatically read from the environment variables,
         so please make sure ANTHROPIC_API_KEY is set.
-        If you want to use Vertex AI, please set the following environment
-        variables:
+        If you want to use Vertex AI, set the `vertexai` argument to True, and
+        please set the following environment variables:
             - ANTHROPIC_VERTEX_PROJECT_ID=<your-project-id>
             - CLOUD_ML_REGION=<region>  (e.g. europe-west1)
             - GOOGLE_APPLICATION_CREDENTIALS=<path-to-credentials-file>

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import warnings
 from typing import Any
 

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -28,16 +28,18 @@ class AnthropicEvalClient(EvalClient):
         *,
         use_async: bool = False,
         system_prompt: str | None = None,
-        project: str | None = None,
-        location: str | None = None,
-        credentials: Credentials | None = None,
+        google_cloud_project: str | None = None,
+        google_cloud_location: str | None = None,
+        google_cloud_credentials: Credentials | None = None,
     ):
         """
         Initialize the Anthropic evaluation client. The authentication
         information is automatically read from the environment variables,
         so please make sure ANTHROPIC_API_KEY is set.
         If you want to use Vertex AI, please set the following arguments:
-        ``project``, ``location``, ``credentials``.
+            - google_cloud_project
+            - google_cloud_location
+            - google_cloud_credentials
 
         References:
             - https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
@@ -50,58 +52,60 @@ class AnthropicEvalClient(EvalClient):
             use_async: (Optional) If True, the async client will be used.
             system_prompt: (Optional) The system prompt to use. If not provided,
                 no system prompt will be used.
-            project: (Optional) The Google Cloud project ID. Needed to use
-                Vertex AI.
-            location: (Optional) The Google Cloud location. Needed to use
-                Vertex AI. (e.g. "europe-west1")
-            credentials: (Optional) The Google Cloud credentials. Needed to use
-                Vertex AI.
+            google_cloud_project: (Optional) The Google Cloud project ID.
+                Needed to use Vertex AI.
+            google_cloud_location: (Optional) The Google Cloud location.
+                Needed to use Vertex AI. (e.g. "europe-west1")
+            google_cloud_credentials: (Optional) The Google Cloud credentials.
+                Needed to use Vertex AI.
         """
         use_vertexai = False
         if (
-            project is not None
-            and location is not None
-            and credentials is not None
+            google_cloud_project is not None
+            and google_cloud_location is not None
+            and google_cloud_credentials is not None
         ):
             use_vertexai = True
         elif any(
             [
-                project is not None,
-                location is not None,
-                credentials is not None,
+                google_cloud_project is not None,
+                google_cloud_location is not None,
+                google_cloud_credentials is not None,
             ]
         ):
             missing_args = []
-            if project is None:
-                missing_args.append("`project`")
-            if location is None:
-                missing_args.append("`location`")
-            if credentials is None:
-                missing_args.append("`credentials`")
+            if google_cloud_project is None:
+                missing_args.append("`google_cloud_project`")
+            if google_cloud_location is None:
+                missing_args.append("`google_cloud_location`")
+            if google_cloud_credentials is None:
+                missing_args.append("`google_cloud_credentials`")
             raise ValueError(
                 f"Missing required Vertex AI arguments: {', '.join(missing_args)}. "
-                "All of `project`, `location`, and `credentials` must be provided to use Vertex AI."
+                "All of `google_cloud_project`, `google_cloud_location`, and `google_cloud_credentials` must be provided to use Vertex AI."
             )
 
         if anthropic_client:
             self._client = anthropic_client
         elif use_vertexai and use_async:
             assert (
-                project is not None and location is not None
+                google_cloud_project is not None
+                and google_cloud_location is not None
             )  # for type checking
             self._client = AsyncAnthropicVertex(
-                project_id=project,
-                region=location,
-                credentials=credentials,
+                project_id=google_cloud_project,
+                region=google_cloud_location,
+                credentials=google_cloud_credentials,
             )
         elif use_vertexai:
             assert (
-                project is not None and location is not None
+                google_cloud_project is not None
+                and google_cloud_location is not None
             )  # for type checking
             self._client = AnthropicVertex(
-                project_id=project,
-                region=location,
-                credentials=credentials,
+                project_id=google_cloud_project,
+                region=google_cloud_location,
+                credentials=google_cloud_credentials,
             )
         elif use_async:
             self._client = AsyncAnthropic()

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -47,8 +47,10 @@ class AnthropicEvalClient(EvalClient):
             anthropic_client: (Optional) The Anthropic client to use.
             anthropic_args: (Optional) dict of additional args to pass in to
                 the ``client.messages.create`` function
-            use_async: (Optional) If True, the async client will be used.
-            vertexai: (Optional) If True, the Vertex AI client will be used.
+            use_async: If True, the async client will be used. Defaults to
+                False.
+            vertexai: If True, the Vertex AI client will be used. Defaults to
+                False.
             system_prompt: (Optional) The system prompt to use. If not provided,
                 no system prompt will be used.
         """

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -11,6 +11,7 @@ from anthropic import (
     AsyncAnthropic,
     AsyncAnthropicVertex,
 )
+from google.oauth2.credentials import Credentials
 
 from langcheck.utils.progress_bar import tqdm_wrapper
 
@@ -28,16 +29,16 @@ class AnthropicEvalClient(EvalClient):
         *,
         use_async: bool = False,
         system_prompt: str | None = None,
+        project: str | None = None,
+        location: str | None = None,
+        credentials: Credentials | None = None,
     ):
         """
         Initialize the Anthropic evaluation client. The authentication
         information is automatically read from the environment variables,
         so please make sure ANTHROPIC_API_KEY is set.
-        If you want to use Vertex AI, please set the following environment
-        variables appropriately:
-        - ANTHROPIC_VERTEX_PROJECT_ID=<your-project-id>
-        - CLOUD_ML_REGION=<region>  (e.g. europe-west1)
-        - GOOGLE_APPLICATION_CREDENTIALS=<path-to-credentials-file>
+        If you want to use Vertex AI, please set the following arguments:
+        ``project``, ``location``, ``credentials``.
 
         References:
             - https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude
@@ -50,14 +51,59 @@ class AnthropicEvalClient(EvalClient):
             use_async: (Optional) If True, the async client will be used.
             system_prompt: (Optional) The system prompt to use. If not provided,
                 no system prompt will be used.
+            project: (Optional) The Google Cloud project ID. Needed to use
+                Vertex AI.
+            location: (Optional) The Google Cloud location. Needed to use
+                Vertex AI. (e.g. "europe-west1")
+            credentials: (Optional) The Google Cloud credentials. Needed to use
+                Vertex AI.
         """
-        use_vertexai = os.getenv("ANTHROPIC_VERTEX_PROJECT_ID") is not None
+        use_vertexai = False
+        if (
+            project is not None
+            and location is not None
+            and credentials is not None
+        ):
+            use_vertexai = True
+        elif any(
+            [
+                project is not None,
+                location is not None,
+                credentials is not None,
+            ]
+        ):
+            missing_args = []
+            if project is None:
+                missing_args.append("`project`")
+            if location is None:
+                missing_args.append("`location`")
+            if credentials is None:
+                missing_args.append("`credentials`")
+            raise ValueError(
+                f"Missing required Vertex AI arguments: {', '.join(missing_args)}. "
+                "All of `project`, `location`, and `credentials` must be provided to use Vertex AI."
+            )
+
         if anthropic_client:
             self._client = anthropic_client
         elif use_vertexai and use_async:
-            self._client = AsyncAnthropicVertex()
+            assert (
+                project is not None and location is not None
+            )  # for type checking
+            self._client = AsyncAnthropicVertex(
+                project_id=project,
+                region=location,
+                credentials=credentials,
+            )
         elif use_vertexai:
-            self._client = AnthropicVertex()
+            assert (
+                project is not None and location is not None
+            )  # for type checking
+            self._client = AnthropicVertex(
+                project_id=project,
+                region=location,
+                credentials=credentials,
+            )
         elif use_async:
             self._client = AsyncAnthropic()
         else:

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -32,8 +32,8 @@ class GeminiEvalClient(EvalClient):
         Initialize the Gemini evaluation client. The authentication
         information is automatically read from the environment variables,
         so please make sure GOOGLE_API_KEY is set.
-        If you want to use Vertex AI, please set the following environment
-        variables:
+        If you want to use Vertex AI, set the `vertexai` argument to True, and
+        please set the following environment variables:
             - GOOGLE_CLOUD_PROJECT=<your-project-id>
             - GOOGLE_CLOUD_LOCATION=<location>  (e.g. europe-west1)
             - GOOGLE_APPLICATION_CREDENTIALS=<path-to-your-credentials>

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -27,16 +27,18 @@ class GeminiEvalClient(EvalClient):
         *,
         use_async: bool = False,
         system_prompt: str | None = None,
-        project: str | None = None,
-        location: str | None = None,
-        credentials: Credentials | None = None,
+        google_cloud_project: str | None = None,
+        google_cloud_location: str | None = None,
+        google_cloud_credentials: Credentials | None = None,
     ):
         """
         Initialize the Gemini evaluation client. The authentication
         information is automatically read from the environment variables,
         so please make sure GOOGLE_API_KEY is set.
         If you want to use Vertex AI, please set the following arguments:
-        ``project``, ``location``, ``credentials``.
+            - google_cloud_project
+            - google_cloud_location
+            - google_cloud_credentials
 
         References:
             - https://ai.google.dev/api/python/google/generativeai/GenerativeModel
@@ -55,12 +57,12 @@ class GeminiEvalClient(EvalClient):
             system_prompt: (Optional) The system prompt for ``generate_content``
                 in ``get_text_responses`` function. If not provided, no system
                 prompt will be used.
-            project: (Optional) The Google Cloud project ID. Needed to use
-                Vertex AI.
-            location: (Optional) The Google Cloud location. Needed to use
-                Vertex AI. (e.g. "europe-west1")
-            credentials: (Optional) The Google Cloud credentials. Needed to use
-                Vertex AI.
+            google_cloud_project: (Optional) The Google Cloud project ID.
+                Needed to use Vertex AI.
+            google_cloud_location: (Optional) The Google Cloud location.
+                Needed to use Vertex AI. (e.g. "europe-west1")
+            google_cloud_credentials: (Optional) The Google Cloud credentials.
+                Needed to use Vertex AI.
         """
         self._model_name = model_name
         self._generate_content_args = generate_content_args or {}
@@ -69,34 +71,34 @@ class GeminiEvalClient(EvalClient):
         self._system_instruction = system_prompt
 
         if (
-            project is not None
-            and location is not None
-            and credentials is not None
+            google_cloud_project is not None
+            and google_cloud_location is not None
+            and google_cloud_credentials is not None
         ):
             self.client = genai.Client(
                 vertexai=True,
-                project=project,
-                location=location,
-                credentials=credentials,
+                project=google_cloud_project,
+                location=google_cloud_location,
+                credentials=google_cloud_credentials,
             )
         elif any(
             [
-                project is not None,
-                location is not None,
-                credentials is not None,
+                google_cloud_project is not None,
+                google_cloud_location is not None,
+                google_cloud_credentials is not None,
             ]
         ):
             missing_args = []
-            if project is None:
-                missing_args.append("`project`")
-            if location is None:
-                missing_args.append("`location`")
-            if credentials is None:
-                missing_args.append("`credentials`")
+            if google_cloud_project is None:
+                missing_args.append("`google_cloud_project`")
+            if google_cloud_location is None:
+                missing_args.append("`google_cloud_location`")
+            if google_cloud_credentials is None:
+                missing_args.append("`google_cloud_credentials`")
 
             raise ValueError(
                 f"Missing required Vertex AI arguments: {', '.join(missing_args)}. "
-                "All of `project`, `location`, and `credentials` must be provided to use Vertex AI."
+                "All of `google_cloud_project`, `google_cloud_location`, and `google_cloud_credentials` must be provided to use Vertex AI."
             )
         else:
             self.client = genai.Client()

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -43,17 +43,16 @@ class GeminiEvalClient(EvalClient):
             - https://cloud.google.com/docs/authentication/application-default-credentials
 
         Args:
-            model_name: (Optional) The Gemini model to use. Defaults to
-                "gemini-1.5-flash".
+            model_name: The Gemini model to use. Defaults to "gemini-1.5-flash".
             generate_content_args: (Optional) Dict of args to pass in to the
                 ``generate_content`` function. The keys should be the same as
                 the keys in the ``genai.types.GenerateContentConfig`` type.
-            embed_model_name: (Optional) The name of the embedding model to use.
-                If not provided, the models/text-embedding-004 model will be used.
-            use_async: (Optional) If True, the async client will be used.
-                Defaults to False.
-            vertexai: (Optional) If True, the Vertex AI client will be used.
-                Defaults to False.
+            embed_model_name: The name of the embedding model to use. If not
+                provided, the "models/text-embedding-004" model will be used.
+            use_async: If True, the async client will be used. Defaults to
+                False.
+            vertexai: If True, the Vertex AI client will be used. Defaults to
+                False.
             system_prompt: (Optional) The system prompt for ``generate_content``
                 in ``get_text_responses`` function. If not provided, no system
                 prompt will be used.

--- a/src/langcheck/metrics/eval_clients/_llama.py
+++ b/src/langcheck/metrics/eval_clients/_llama.py
@@ -42,8 +42,8 @@ class LlamaEvalClient(EvalClient):
             tensor_parallel_size: The number of GPUs to use for distributed
             execution with tensor parallelism.
             device: The device to load the model on.
-            system_prompt: The system prompt to use. If not provided, default
-                system prompts based on the language will be used.
+            system_prompt: (Optional) The system prompt to use. If not provided,
+                default system prompts based on the language will be used.
         """
         self._model = LLM(
             model=model_name,

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -35,7 +35,8 @@ class OpenAIEvalClient(EvalClient):
             openai_client: (Optional) The OpenAI client to use.
             openai_args: (Optional) dict of additional args to pass in to the
             ``client.chat.completions.create`` function.
-            use_async: (Optional) If True, the async client will be used.
+            use_async: If True, the async client will be used. Defaults to
+                False.
             system_prompt: (Optional) The system prompt to use. If not provided,
                 no system prompt will be used.
         """

--- a/src/langcheck/metrics/eval_clients/_prometheus.py
+++ b/src/langcheck/metrics/eval_clients/_prometheus.py
@@ -35,8 +35,8 @@ class PrometheusEvalClient(EvalClient):
             tensor_parallel_size: The number of GPUs to use for distributed
             execution with tensor parallelism.
             device: The device to load the model on.
-            system_prompt: The system prompt to use. If not provided, no
-                system prompt will be used.
+            system_prompt: (Optional) The system prompt to use. If not provided,
+                no system prompt will be used.
         """
         self._model = LLM(
             model=model_name,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_environment():
+    original_env = dict(os.environ)
+
+    yield
+
+    os.environ.clear()
+    os.environ.update(original_env)

--- a/tests/metrics/eval_clients/test_anthropic.py
+++ b/tests/metrics/eval_clients/test_anthropic.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from anthropic.types.message import Message
-from google.oauth2.credentials import Credentials
 
 from langcheck.metrics.eval_clients import AnthropicEvalClient
 
@@ -41,12 +40,11 @@ def test_get_text_response_anthropic_vertex_ai(system_prompt):
     with patch(
         "anthropic.resources.Messages.create", return_value=mock_chat_completion
     ):
-        client = AnthropicEvalClient(
-            google_cloud_project="dummy_project",
-            google_cloud_location="dummy_location",
-            google_cloud_credentials=Mock(spec=Credentials),
-            system_prompt=system_prompt,
-        )
+        # Set the necessary env vars for the Vertex AI AnthropicEvalClient
+        os.environ["ANTHROPIC_VERTEX_PROJECT_ID"] = "dummy_project"
+        os.environ["CLOUD_ML_REGION"] = "dummy_location"
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "dummy_credentials_path"
+        client = AnthropicEvalClient(vertexai=True, system_prompt=system_prompt)
         responses = client.get_text_responses(prompts)
         assert len(responses) == len(prompts)
         for response in responses:
@@ -99,12 +97,11 @@ def test_get_float_score_anthropic_vertex_ai(system_prompt, language):
     with patch(
         "anthropic.resources.Messages.create", return_value=mock_chat_completion
     ):
-        client = AnthropicEvalClient(
-            google_cloud_project="dummy_project",
-            google_cloud_location="dummy_location",
-            google_cloud_credentials=Mock(spec=Credentials),
-            system_prompt=system_prompt,
-        )
+        # Set the necessary env vars for the Vertex AI AnthropicEvalClient
+        os.environ["ANTHROPIC_VERTEX_PROJECT_ID"] = "dummy_project"
+        os.environ["CLOUD_ML_REGION"] = "dummy_location"
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "dummy_credentials_path"
+        client = AnthropicEvalClient(vertexai=True, system_prompt=system_prompt)
 
         scores = client.get_float_score(
             "dummy_metric", language, unstructured_assessment_result, score_map

--- a/tests/metrics/eval_clients/test_anthropic.py
+++ b/tests/metrics/eval_clients/test_anthropic.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from anthropic.types.message import Message
+from google.oauth2.credentials import Credentials
 
 from langcheck.metrics.eval_clients import AnthropicEvalClient
 
@@ -23,6 +24,29 @@ def test_get_text_response_anthropic(system_prompt):
         # Set the necessary env vars for the AnthropicEvalClient
         os.environ["ANTHROPIC_API_KEY"] = "dummy_key"
         client = AnthropicEvalClient(system_prompt=system_prompt)
+        responses = client.get_text_responses(prompts)
+        assert len(responses) == len(prompts)
+        for response in responses:
+            assert response == answer
+
+
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+def test_get_text_response_anthropic_vertex_ai(system_prompt):
+    prompts = ["Assess the factual consistency of the generated output..."] * 2
+    answer = "The output is fully factually consistent."
+    mock_chat_completion = Mock(spec=Message)
+    mock_chat_completion.content = [Mock(text=answer)]
+    # Calling the anthropic.resources.Messages.create method requires a Google
+    # Cloud credentials, so we mock the return value instead
+    with patch(
+        "anthropic.resources.Messages.create", return_value=mock_chat_completion
+    ):
+        client = AnthropicEvalClient(
+            google_cloud_project="dummy_project",
+            google_cloud_location="dummy_location",
+            google_cloud_credentials=Mock(spec=Credentials),
+            system_prompt=system_prompt,
+        )
         responses = client.get_text_responses(prompts)
         assert len(responses) == len(prompts)
         for response in responses:
@@ -49,6 +73,38 @@ def test_get_float_score_anthropic(system_prompt, language):
         # Set the necessary env vars for the AnthropicEvalClient
         os.environ["ANTHROPIC_API_KEY"] = "dummy_key"
         client = AnthropicEvalClient(system_prompt=system_prompt)
+
+        scores = client.get_float_score(
+            "dummy_metric", language, unstructured_assessment_result, score_map
+        )
+        assert len(scores) == len(unstructured_assessment_result)
+        for score in scores:
+            assert score == 1.0
+
+
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+@pytest.mark.parametrize("language", ["en", "de", "ja"])
+def test_get_float_score_anthropic_vertex_ai(system_prompt, language):
+    unstructured_assessment_result: list[str | None] = [
+        "The output is fully factually consistent."
+    ] * 2
+    short_assessment_result = "Fully Consistent"
+    score_map = {short_assessment_result: 1.0}
+
+    mock_chat_completion = Mock(spec=Message)
+    mock_chat_completion.content = [Mock(text=short_assessment_result)]
+
+    # Calling the anthropic.resources.Messages.create method requires a Google
+    # Cloud credentials, so we mock the return value instead
+    with patch(
+        "anthropic.resources.Messages.create", return_value=mock_chat_completion
+    ):
+        client = AnthropicEvalClient(
+            google_cloud_project="dummy_project",
+            google_cloud_location="dummy_location",
+            google_cloud_credentials=Mock(spec=Credentials),
+            system_prompt=system_prompt,
+        )
 
         scores = client.get_float_score(
             "dummy_metric", language, unstructured_assessment_result, score_map

--- a/tests/metrics/eval_clients/test_gemini.py
+++ b/tests/metrics/eval_clients/test_gemini.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from google.genai import types
+from google.oauth2.credentials import Credentials
 from pydantic import BaseModel
 
 from langcheck.metrics.eval_clients import GeminiEvalClient
@@ -18,8 +19,8 @@ def test_get_text_response_gemini(system_prompt):
     mock_response = Mock(spec=types.GenerateContentResponse)
     mock_response.text = answer
     mock_response.candidates = [Mock(finish_reason=1)]
-    # Calling the google.genai.models.Models.generate_content method
-    # requires a Google API key, so we mock the return value instead
+    # Calling the google.genai.models.Models.generate_content method requires a
+    # Google API key, so we mock the return value instead
     with patch(
         "google.genai.models.Models.generate_content",
         return_value=mock_response,
@@ -27,6 +28,31 @@ def test_get_text_response_gemini(system_prompt):
         # Set the necessary env vars for the GeminiEvalClient
         os.environ["GOOGLE_API_KEY"] = "dummy_key"
         client = GeminiEvalClient(system_prompt=system_prompt)
+        responses = client.get_text_responses(prompts)
+        assert len(responses) == len(prompts)
+        for response in responses:
+            assert response == answer
+
+
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+def test_get_text_response_gemini_vertex_ai(system_prompt):
+    prompts = ["Assess the factual consistency of the generated output..."] * 2
+    answer = "The output is fully factually consistent."
+    mock_response = Mock(spec=types.GenerateContentResponse)
+    mock_response.text = answer
+    mock_response.candidates = [Mock(finish_reason=1)]
+    # Calling the google.genai.models.Models.generate_content method requires a
+    # Google Cloud credentials, so we mock the return value instead
+    with patch(
+        "google.genai.models.Models.generate_content",
+        return_value=mock_response,
+    ):
+        client = GeminiEvalClient(
+            google_cloud_project="dummy_project",
+            google_cloud_location="dummy_location",
+            google_cloud_credentials=Mock(spec=Credentials),
+            system_prompt=system_prompt,
+        )
         responses = client.get_text_responses(prompts)
         assert len(responses) == len(prompts)
         for response in responses:
@@ -49,8 +75,8 @@ def test_get_float_score_gemini(system_prompt, language):
     mock_response.parsed = Response(score=short_assessment_result)
     mock_response.candidates = [Mock(finish_reason=1)]
 
-    # Calling the google.genai.models.Models.generate_content method
-    # requires a Google API key, so we mock the return value instead
+    # Calling the google.genai.models.Models.generate_content method requires a
+    # Google API key, so we mock the return value instead
     with patch(
         "google.genai.models.Models.generate_content",
         return_value=mock_response,
@@ -67,11 +93,48 @@ def test_get_float_score_gemini(system_prompt, language):
             assert score == 1.0
 
 
+@pytest.mark.parametrize("system_prompt", [None, "Answer in English."])
+@pytest.mark.parametrize("language", ["en", "de", "ja"])
+def test_get_float_score_gemini_vertex_ai(system_prompt, language):
+    unstructured_assessment_result: list[str | None] = [
+        "The output is fully factually consistent."
+    ] * 2
+    short_assessment_result = "Fully Consistent"
+    score_map = {short_assessment_result: 1.0}
+
+    class Response(BaseModel):
+        score: Literal[tuple(score_map.keys())]  # type: ignore
+
+    mock_response = Mock(spec=types.GenerateContentResponse)
+    mock_response.parsed = Response(score=short_assessment_result)
+    mock_response.candidates = [Mock(finish_reason=1)]
+
+    # Calling the google.genai.models.Models.generate_content method requires a
+    # Google Cloud credentials, so we mock the return value instead
+    with patch(
+        "google.genai.models.Models.generate_content",
+        return_value=mock_response,
+    ):
+        client = GeminiEvalClient(
+            google_cloud_project="dummy_project",
+            google_cloud_location="dummy_location",
+            google_cloud_credentials=Mock(spec=Credentials),
+            system_prompt=system_prompt,
+        )
+
+        scores = client.get_float_score(
+            "dummy_metric", language, unstructured_assessment_result, score_map
+        )
+        assert len(scores) == len(unstructured_assessment_result)
+        for score in scores:
+            assert score == 1.0
+
+
 def test_similarity_scorer_gemini():
     mock_embedding_response = [0.1, 0.2, 0.3]
 
-    # Calling the google.genai.models.Models.embed_content method requires a Google
-    # API key, so we mock the return value instead
+    # Calling the google.genai.models.Models.embed_content method requires a
+    # Google API key, so we mock the return value instead
     with patch(
         "google.genai.models.Models.embed_content",
         Mock(
@@ -85,6 +148,35 @@ def test_similarity_scorer_gemini():
         # Set the necessary env vars for the GeminiEvalClient
         os.environ["GOOGLE_API_KEY"] = "dummy_key"
         gemini_client = GeminiEvalClient()
+        scorer = gemini_client.similarity_scorer()
+        # Since the mock embeddings are the same for the generated and reference
+        # outputs, the similarity score should be 1.
+        score = scorer.score(
+            ["The cat sat on the mat."], ["The cat sat on the mat."]
+        )
+        assert 0.99 <= score[0] <= 1
+
+
+def test_similarity_scorer_gemini_vertex_ai():
+    mock_embedding_response = [0.1, 0.2, 0.3]
+
+    # Calling the google.genai.models.Models.embed_content method requires a
+    # Google Cloud credentials, so we mock the return value instead
+    with patch(
+        "google.genai.models.Models.embed_content",
+        Mock(
+            return_value=types.EmbedContentResponse(
+                embeddings=[
+                    types.ContentEmbedding(values=mock_embedding_response)
+                ]
+            )
+        ),
+    ):
+        gemini_client = GeminiEvalClient(
+            google_cloud_project="dummy_project",
+            google_cloud_location="dummy_location",
+            google_cloud_credentials=Mock(spec=Credentials),
+        )
         scorer = gemini_client.similarity_scorer()
         # Since the mock embeddings are the same for the generated and reference
         # outputs, the similarity score should be 1.

--- a/tests/metrics/eval_clients/test_gemini.py
+++ b/tests/metrics/eval_clients/test_gemini.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from google.genai import types
-from google.oauth2.credentials import Credentials
 from pydantic import BaseModel
 
 from langcheck.metrics.eval_clients import GeminiEvalClient
@@ -47,12 +46,11 @@ def test_get_text_response_gemini_vertex_ai(system_prompt):
         "google.genai.models.Models.generate_content",
         return_value=mock_response,
     ):
-        client = GeminiEvalClient(
-            google_cloud_project="dummy_project",
-            google_cloud_location="dummy_location",
-            google_cloud_credentials=Mock(spec=Credentials),
-            system_prompt=system_prompt,
-        )
+        # Set the necessary env vars for the Vertex AI GeminiEvalClient
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "dummy_project"
+        os.environ["GOOGLE_CLOUD_LOCATION"] = "dummy_location"
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "dummy_credentials_path"
+        client = GeminiEvalClient(vertexai=True, system_prompt=system_prompt)
         responses = client.get_text_responses(prompts)
         assert len(responses) == len(prompts)
         for response in responses:
@@ -115,12 +113,11 @@ def test_get_float_score_gemini_vertex_ai(system_prompt, language):
         "google.genai.models.Models.generate_content",
         return_value=mock_response,
     ):
-        client = GeminiEvalClient(
-            google_cloud_project="dummy_project",
-            google_cloud_location="dummy_location",
-            google_cloud_credentials=Mock(spec=Credentials),
-            system_prompt=system_prompt,
-        )
+        # Set the necessary env vars for the Vertex AI GeminiEvalClient
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "dummy_project"
+        os.environ["GOOGLE_CLOUD_LOCATION"] = "dummy_location"
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "dummy_credentials_path"
+        client = GeminiEvalClient(vertexai=True, system_prompt=system_prompt)
 
         scores = client.get_float_score(
             "dummy_metric", language, unstructured_assessment_result, score_map
@@ -172,11 +169,11 @@ def test_similarity_scorer_gemini_vertex_ai():
             )
         ),
     ):
-        gemini_client = GeminiEvalClient(
-            google_cloud_project="dummy_project",
-            google_cloud_location="dummy_location",
-            google_cloud_credentials=Mock(spec=Credentials),
-        )
+        # Set the necessary env vars for the Vertex AI GeminiEvalClient
+        os.environ["GOOGLE_CLOUD_PROJECT"] = "dummy_project"
+        os.environ["GOOGLE_CLOUD_LOCATION"] = "dummy_location"
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "dummy_credentials_path"
+        gemini_client = GeminiEvalClient(vertexai=True)
         scorer = gemini_client.similarity_scorer()
         # Since the mock embeddings are the same for the generated and reference
         # outputs, the similarity score should be 1.


### PR DESCRIPTION
This PR changes the Vertex AI eval clients to pass necessary info from EvalClient init arguments instead of environment variables so that we can easily use Vertex AI client and non Vertex AI client.
This also bumps the version to `0.10.0.dev3`.

```python
from dotenv import load_dotenv

load_dotenv()

from langcheck.metrics.eval_clients import (
    AnthropicEvalClient,
    GeminiEvalClient,
)

# The following environment variables should be set
# ANTHROPIC_VERTEX_PROJECT_ID=<your-project-id>
# CLOUD_ML_REGION=<region>  (e.g. europe-west1)
# GOOGLE_APPLICATION_CREDENTIALS=<path-to-credentials-file>
anthropic_client = AnthropicEvalClient(vertexai=True)

# The following environment variables should be set
# GOOGLE_CLOUD_PROJECT=<your-project-id>
# GOOGLE_CLOUD_LOCATION=<location>  (e.g. europe-west1)
# GOOGLE_APPLICATION_CREDENTIALS=<path-to-credentials-file>
gemini_client = GeminiEvalClient(
    model_name="gemini-2.0-flash",
    embed_model_name="text-embedding-004",
    vertexai=True
)

anthropic_response = anthropic_client.get_text_responses(
    prompts=["Hello"]
)
gemini_response = gemini_client.get_text_responses(
    prompts=["Hello"]
)

```