### PR TITLE
Add genai client argument to gemini eval client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.10.0.dev3"
+version = "0.10.0.dev4"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]

--- a/src/langcheck/__init__.py
+++ b/src/langcheck/__init__.py
@@ -1,4 +1,4 @@
 from langcheck import augment, metrics, plot, utils
 
 __all__ = ["augment", "metrics", "plot", "utils"]
-__version__ = "0.10.0.dev3"
+__version__ = "0.10.0.dev4"

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -110,13 +110,36 @@ class AnthropicEvalClient(EvalClient):
             self._use_async = use_async
         else:
             self._client = anthropic_client
-
             self._vertexai = isinstance(
                 anthropic_client, (AnthropicVertex, AsyncAnthropicVertex)
             )
             self._use_async = isinstance(
                 anthropic_client, (AsyncAnthropic, AsyncAnthropicVertex)
             )
+
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
+            if self._vertexai and not vertexai:
+                warnings.warn(
+                    "Using an Vertex AI client but `vertexai` is False. "
+                    "Vertex AI client will be used."
+                )
+            elif not self._vertexai and vertexai:
+                warnings.warn(
+                    "Using Anthropic client but `vertexai` is True. "
+                    "Anthropic client will be used."
+                )
+
+            if self._use_async and not use_async:
+                warnings.warn(
+                    "Using an AsyncAnthropic client but use_async is False. "
+                    "AsyncAnthropic client will be used."
+                )
+            elif not self._use_async and use_async:
+                warnings.warn(
+                    "Using Anthropic client but use_async is True. "
+                    "Anthropic client will be used."
+                )
 
         self._anthropic_args = anthropic_args or {}
         self._system_prompt = system_prompt
@@ -282,6 +305,30 @@ class AnthropicExtractor(Extractor):
             self._vertexai = isinstance(
                 anthropic_client, (AnthropicVertex, AsyncAnthropicVertex)
             )
+
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
+            if self._vertexai and not vertexai:
+                warnings.warn(
+                    "Using an Vertex AI client but `vertexai` is False. "
+                    "Vertex AI client will be used."
+                )
+            elif not self._vertexai and vertexai:
+                warnings.warn(
+                    "Using Anthropic client but `vertexai` is True. "
+                    "Anthropic client will be used."
+                )
+
+            if self._use_async and not use_async:
+                warnings.warn(
+                    "Using an AsyncAnthropic client but use_async is False. "
+                    "AsyncAnthropic client will be used."
+                )
+            elif not self._use_async and use_async:
+                warnings.warn(
+                    "Using Anthropic client but use_async is True. "
+                    "Anthropic client will be used."
+                )
 
         self._anthropic_args = anthropic_args or {}
 

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -121,24 +121,24 @@ class AnthropicEvalClient(EvalClient):
             # argument will be ignored.
             if self._vertexai and not vertexai:
                 warnings.warn(
-                    "Using an Vertex AI client but `vertexai` is False. "
-                    "Vertex AI client will be used."
+                    "The provided `anthropic_client` is a Vertex AI client, "
+                    "so the `vertexai=False` argument will be ignored. The Vertex AI client will be used."
                 )
             elif not self._vertexai and vertexai:
                 warnings.warn(
-                    "Using Anthropic client but `vertexai` is True. "
-                    "Anthropic client will be used."
+                    "The provided `anthropic_client` is an Anthropic client, "
+                    "so the `vertexai=True` argument will be ignored. The Anthropic client will be used."
                 )
 
             if self._use_async and not use_async:
                 warnings.warn(
-                    "Using an AsyncAnthropic client but use_async is False. "
-                    "AsyncAnthropic client will be used."
+                    "The provided `anthropic_client` is an async client, "
+                    "so the `use_async=False` argument will be ignored. The async client will be used."
                 )
             elif not self._use_async and use_async:
                 warnings.warn(
-                    "Using Anthropic client but use_async is True. "
-                    "Anthropic client will be used."
+                    "The provided `anthropic_client` is a synchronous client, "
+                    "so the `use_async=True` argument will be ignored. The synchronous client will be used."
                 )
 
         self._anthropic_args = anthropic_args or {}
@@ -310,24 +310,24 @@ class AnthropicExtractor(Extractor):
             # argument will be ignored.
             if self._vertexai and not vertexai:
                 warnings.warn(
-                    "Using an Vertex AI client but `vertexai` is False. "
-                    "Vertex AI client will be used."
+                    "The provided `anthropic_client` is a Vertex AI client, "
+                    "so the `vertexai=False` argument will be ignored. The Vertex AI client will be used."
                 )
             elif not self._vertexai and vertexai:
                 warnings.warn(
-                    "Using Anthropic client but `vertexai` is True. "
-                    "Anthropic client will be used."
+                    "The provided `anthropic_client` is an Anthropic client, "
+                    "so the `vertexai=True` argument will be ignored. The Anthropic client will be used."
                 )
 
             if self._use_async and not use_async:
                 warnings.warn(
-                    "Using an AsyncAnthropic client but use_async is False. "
-                    "AsyncAnthropic client will be used."
+                    "The provided `anthropic_client` is an async client, "
+                    "so the `use_async=False` argument will be ignored. The async client will be used."
                 )
             elif not self._use_async and use_async:
                 warnings.warn(
-                    "Using Anthropic client but use_async is True. "
-                    "Anthropic client will be used."
+                    "The provided `anthropic_client` is a synchronous client, "
+                    "so the `use_async=True` argument will be ignored. The synchronous client will be used."
                 )
 
         self._anthropic_args = anthropic_args or {}

--- a/src/langcheck/metrics/eval_clients/_anthropic.py
+++ b/src/langcheck/metrics/eval_clients/_anthropic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import warnings
 from typing import Any
 
@@ -23,7 +24,11 @@ class AnthropicEvalClient(EvalClient):
 
     def __init__(
         self,
-        anthropic_client: Anthropic | None = None,
+        anthropic_client: Anthropic
+        | AsyncAnthropic
+        | AnthropicVertex
+        | AsyncAnthropicVertex
+        | None = None,
         anthropic_args: dict[str, Any] | None = None,
         *,
         use_async: bool = False,
@@ -49,29 +54,71 @@ class AnthropicEvalClient(EvalClient):
             anthropic_client (Optional): The Anthropic client to use.
             anthropic_args (Optional): dict of additional args to pass in to
                 the `client.messages.create` function
-            use_async: If True, the async client will be used. Defaults to
-                False.
-            vertexai: If True, the Vertex AI client will be used. Defaults to
-                False.
+            use_async: If True, the async client will be used. Ignored when
+                `anthropic_client` is provided. Defaults to False.
+            vertexai: If True, the Vertex AI client will be used. Ignored when
+                `anthropic_client` is provided. Defaults to False.
             system_prompt (Optional): The system prompt to use. If not provided,
                 no system prompt will be used.
             extractor (Optional): The extractor to use. If not provided, the
                 default extractor will be used.
         """
-        if anthropic_client:
-            self._client = anthropic_client
-        elif vertexai and use_async:
-            self._client = AsyncAnthropicVertex()
-        elif vertexai:
-            self._client = AnthropicVertex()
-        elif use_async:
-            self._client = AsyncAnthropic()
+
+        if anthropic_client is None:
+            if vertexai:
+                # Vertex AI requires these environment variables
+                for env_var in [
+                    "ANTHROPIC_VERTEX_PROJECT_ID",
+                    "CLOUD_ML_REGION",
+                    "GOOGLE_APPLICATION_CREDENTIALS",
+                ]:
+                    if not os.environ.get(env_var):
+                        raise ValueError(
+                            f"Environment variable '{env_var}' must be set when using Vertex AI."
+                        )
+
+                if not os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID"):
+                    raise ValueError(
+                        "`ANTHROPIC_VERTEX_PROJECT_ID` must be set when using Vertex AI."
+                    )
+
+                # Warn that `ANTHROPIC_API_KEY` is not used when using Vertex AI
+                if os.environ.get("ANTHROPIC_API_KEY", None):
+                    warnings.warn(
+                        "`ANTHROPIC_API_KEY` is set when using Vertex AI. "
+                        "Vertex AI will take precedence over the API key from "
+                        "the environment variable."
+                    )
+
+                if use_async:
+                    self._client = AsyncAnthropicVertex()
+                else:
+                    self._client = AnthropicVertex()
+            else:
+                if os.environ.get("ANTHROPIC_API_KEY", None) is None:
+                    raise ValueError(
+                        "`ANTHROPIC_API_KEY` is not set when using Anthropic API. "
+                        "Please set the `ANTHROPIC_API_KEY` environment variable."
+                    )
+
+                if use_async:
+                    self._client = AsyncAnthropic()
+                else:
+                    self._client = Anthropic()
+
+            self._vertexai = vertexai
+            self._use_async = use_async
         else:
-            self._client = Anthropic()
+            self._client = anthropic_client
+
+            self._vertexai = isinstance(
+                anthropic_client, (AnthropicVertex, AsyncAnthropicVertex)
+            )
+            self._use_async = isinstance(
+                anthropic_client, (AsyncAnthropic, AsyncAnthropicVertex)
+            )
 
         self._anthropic_args = anthropic_args or {}
-        self._use_async = use_async
-        self._vertexai = vertexai
         self._system_prompt = system_prompt
 
         if system_prompt and "system" in self._anthropic_args:
@@ -177,25 +224,66 @@ class AnthropicExtractor(Extractor):
             anthropic_client (Optional): The Anthropic client to use.
             anthropic_args (Optional): dict of additional args to pass in to
                 the `client.messages.create` function
-            use_async: If True, the async client will be used. Defaults to
-                False.
-            vertexai: If True, the Vertex AI client will be used. Defaults to
-                False.
+            use_async: If True, the async client will be used. Ignored when
+                `anthropic_client` is provided. Defaults to False.
+            vertexai: If True, the Vertex AI client will be used. Ignored when
+                `anthropic_client` is provided. Defaults to False.
         """
-        if anthropic_client:
-            self._client = anthropic_client
-        elif vertexai and use_async:
-            self._client = AsyncAnthropicVertex()
-        elif vertexai:
-            self._client = AnthropicVertex()
-        elif use_async:
-            self._client = AsyncAnthropic()
+        if anthropic_client is None:
+            if vertexai:
+                # Vertex AI requires these environment variables
+                for env_var in [
+                    "ANTHROPIC_VERTEX_PROJECT_ID",
+                    "CLOUD_ML_REGION",
+                    "GOOGLE_APPLICATION_CREDENTIALS",
+                ]:
+                    if not os.environ.get(env_var):
+                        raise ValueError(
+                            f"Environment variable '{env_var}' must be set when using Vertex AI."
+                        )
+
+                if not os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID"):
+                    raise ValueError(
+                        "`ANTHROPIC_VERTEX_PROJECT_ID` must be set when using Vertex AI."
+                    )
+
+                # Warn that `ANTHROPIC_API_KEY` is not used when using Vertex AI
+                if os.environ.get("ANTHROPIC_API_KEY", None):
+                    warnings.warn(
+                        "`ANTHROPIC_API_KEY` is set when using Vertex AI. "
+                        "Vertex AI will take precedence over the API key from "
+                        "the environment variable."
+                    )
+
+                if use_async:
+                    self._client = AsyncAnthropicVertex()
+                else:
+                    self._client = AnthropicVertex()
+            else:
+                if os.environ.get("ANTHROPIC_API_KEY", None) is None:
+                    raise ValueError(
+                        "`ANTHROPIC_API_KEY` is not set when using Anthropic API. "
+                        "Please set the `ANTHROPIC_API_KEY` environment variable."
+                    )
+
+                if use_async:
+                    self._client = AsyncAnthropic()
+                else:
+                    self._client = Anthropic()
+
+            self._use_async = use_async
+            self._vertexai = vertexai
+
         else:
-            self._client = Anthropic()
+            self._client = anthropic_client
+            self._use_async = isinstance(
+                anthropic_client, (AsyncAnthropic, AsyncAnthropicVertex)
+            )
+            self._vertexai = isinstance(
+                anthropic_client, (AnthropicVertex, AsyncAnthropicVertex)
+            )
 
         self._anthropic_args = anthropic_args or {}
-        self._use_async = use_async
-        self._vertexai = vertexai
 
     def get_float_score(
         self,

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -105,13 +105,30 @@ class GeminiEvalClient(EvalClient):
                     "Please set the `GOOGLE_API_KEY` environment variable."
                 )
             self._client = genai.Client(vertexai=vertexai)
+            self._vertexai = vertexai
+
         else:
             self._client = genai_client
+            self._vertexai = genai_client.vertexai
+
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
+            if self._vertexai and not vertexai:
+                warnings.warn(
+                    "Using an Vertex AI client but `vertexai` is False. "
+                    "Vertex AI client will be used."
+                )
+            elif not self._vertexai and vertexai:
+                warnings.warn(
+                    "Using Gemini Developer client but `vertexai` is True. "
+                    "Gemini Developer client will be used."
+                )
 
         if extractor is None:
             self._extractor = GeminiExtractor(
                 genai_client=self._client,
-                use_async=use_async,
+                use_async=self._use_async,
+                vertexai=self._vertexai,
             )
         else:
             self._extractor = extractor
@@ -282,6 +299,18 @@ class GeminiExtractor(Extractor):
             self._client = genai.Client(vertexai=vertexai)
         else:
             self._client = genai_client
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
+            if genai_client.vertexai and not vertexai:
+                warnings.warn(
+                    "Using an Vertex AI client but `vertexai` is False. "
+                    "Vertex AI client will be used."
+                )
+            elif not genai_client.vertexai and vertexai:
+                warnings.warn(
+                    "Using Gemini Developer client but `vertexai` is True. "
+                    "Gemini Developer client will be used."
+                )
 
     def get_float_score(
         self,

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -213,11 +213,7 @@ class GeminiSimilarityScorer(BaseSimilarityScorer):
                 )
                 return embed_response
 
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:  # pragma: py-lt-310
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
+            loop = asyncio.get_event_loop()
             embed_response = loop.run_until_complete(_call_async_api())
         else:
             embed_response = self._client.models.embed_content(

--- a/src/langcheck/metrics/eval_clients/_gemini.py
+++ b/src/langcheck/metrics/eval_clients/_gemini.py
@@ -115,13 +115,13 @@ class GeminiEvalClient(EvalClient):
             # argument will be ignored.
             if self._vertexai and not vertexai:
                 warnings.warn(
-                    "Using an Vertex AI client but `vertexai` is False. "
-                    "Vertex AI client will be used."
+                    "The provided `genai_client` is a Vertex AI client, "
+                    "so the `vertexai=False` argument will be ignored. The Vertex AI client will be used."
                 )
             elif not self._vertexai and vertexai:
                 warnings.warn(
-                    "Using Gemini Developer client but `vertexai` is True. "
-                    "Gemini Developer client will be used."
+                    "The provided `genai_client` is a Gemini Developer client, "
+                    "so the `vertexai=True` argument will be ignored. The Gemini Developer client will be used."
                 )
 
         if extractor is None:
@@ -299,13 +299,13 @@ class GeminiExtractor(Extractor):
             # argument will be ignored.
             if genai_client.vertexai and not vertexai:
                 warnings.warn(
-                    "Using an Vertex AI client but `vertexai` is False. "
-                    "Vertex AI client will be used."
+                    "The provided `genai_client` is a Vertex AI client, "
+                    "so the `vertexai=False` argument will be ignored. The Vertex AI client will be used."
                 )
             elif not genai_client.vertexai and vertexai:
                 warnings.warn(
-                    "Using Gemini Developer client but `vertexai` is True. "
-                    "Gemini Developer client will be used."
+                    "The provided `genai_client` is a Gemini Developer client, "
+                    "so the `vertexai=True` argument will be ignored. The Gemini Developer client will be used."
                 )
 
     def get_float_score(

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -54,13 +54,13 @@ class OpenAIEvalClient(EvalClient):
             # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
-                    "Using an AsyncOpenAI client but use_async is False. "
-                    "AsyncOpenAI client will be used."
+                    "The provided `openai_client` is an async client, "
+                    "so the `use_async=False` argument will be ignored. The async client will be used."
                 )
             elif not self._use_async and use_async:
                 warnings.warn(
-                    "Using OpenAI client but use_async is True. "
-                    "OpenAI client will be used."
+                    "The provided `openai_client` is a synchronous client, "
+                    "so the `use_async=True` argument will be ignored. The synchronous client will be used."
                 )
         else:
             self._client = AsyncOpenAI() if use_async else OpenAI()
@@ -294,13 +294,13 @@ class OpenAIExtractor(Extractor):
             # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
-                    "Using an AsyncOpenAI client but use_async is False. "
-                    "AsyncOpenAI client will be used."
+                    "The provided `openai_client` is an async client, "
+                    "so the `use_async=False` argument will be ignored. The async client will be used."
                 )
             elif not self._use_async and use_async:
                 warnings.warn(
-                    "Using OpenAI client but use_async is True. "
-                    "OpenAI client will be used."
+                    "The provided `openai_client` is a synchronous client, "
+                    "so the `use_async=True` argument will be ignored. The synchronous client will be used."
                 )
         else:
             self._client = AsyncOpenAI() if use_async else OpenAI()
@@ -505,13 +505,13 @@ class AzureOpenAIEvalClient(OpenAIEvalClient):
             # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
-                    "Using an AsyncAzureOpenAI client but use_async is False. "
-                    "AsyncAzureOpenAI client will be used."
+                    "The provided `azure_openai_client` is an async client, "
+                    "so the `use_async=False` argument will be ignored. The async client will be used."
                 )
             elif not self._use_async and use_async:
                 warnings.warn(
-                    "Using AzureOpenAI client but use_async is True. "
-                    "AzureOpenAI client will be used."
+                    "The provided `azure_openai_client` is a synchronous client, "
+                    "so the `use_async=True` argument will be ignored. The synchronous client will be used."
                 )
         else:
             self._client = (
@@ -582,13 +582,13 @@ class AzureOpenAIExtractor(OpenAIExtractor):
             # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
-                    "Using an AsyncAzureOpenAI client but use_async is False. "
-                    "AsyncAzureOpenAI client will be used."
+                    "The provided `azure_openai_client` is an async client, "
+                    "so the `use_async=False` argument will be ignored. The async client will be used."
                 )
             elif not self._use_async and use_async:
                 warnings.warn(
-                    "Using AzureOpenAI client but use_async is True. "
-                    "AzureOpenAI client will be used."
+                    "The provided `azure_openai_client` is a synchronous client, "
+                    "so the `use_async=True` argument will be ignored. The synchronous client will be used."
                 )
         else:
             self._client = (

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -49,6 +49,9 @@ class OpenAIEvalClient(EvalClient):
         if openai_client:
             self._client = openai_client
             self._use_async = isinstance(openai_client, AsyncOpenAI)
+
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
                     "Using an AsyncOpenAI client but use_async is False. "
@@ -68,8 +71,8 @@ class OpenAIEvalClient(EvalClient):
 
         if extractor is None:
             self._extractor = OpenAIExtractor(
-                openai_client=openai_client,
-                openai_args=openai_args,
+                openai_client=self._client,
+                openai_args=self._openai_args,
                 use_async=self._use_async,
             )
         else:
@@ -286,6 +289,9 @@ class OpenAIExtractor(Extractor):
         if openai_client:
             self._client = openai_client
             self._use_async = isinstance(openai_client, AsyncOpenAI)
+
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
                     "Using an AsyncOpenAI client but use_async is False. "
@@ -495,6 +501,8 @@ class AzureOpenAIEvalClient(OpenAIEvalClient):
             self._client = azure_openai_client
             self._use_async = isinstance(azure_openai_client, AsyncAzureOpenAI)
 
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
                     "Using an AsyncAzureOpenAI client but use_async is False. "
@@ -570,6 +578,8 @@ class AzureOpenAIExtractor(OpenAIExtractor):
             self._client = azure_openai_client
             self._use_async = isinstance(azure_openai_client, AsyncAzureOpenAI)
 
+            # Client config will take precedence over the argument, and the
+            # argument will be ignored.
             if self._use_async and not use_async:
                 warnings.warn(
                     "Using an AsyncAzureOpenAI client but use_async is False. "

--- a/src/langcheck/metrics/eval_clients/_openai.py
+++ b/src/langcheck/metrics/eval_clients/_openai.py
@@ -70,6 +70,7 @@ class OpenAIEvalClient(EvalClient):
             self._extractor = OpenAIExtractor(
                 openai_client=openai_client,
                 openai_args=openai_args,
+                use_async=self._use_async,
             )
         else:
             self._extractor = extractor


### PR DESCRIPTION
Now GeminiEvalClient can take `genai_client` argument, so that the user can also customize the client manually instead of through environment variables.

I also added environment variables validation to Anthropic and Gemini validations to clarify the behavior (e.g. when given client and `vertexai` or `use_async` at the same time)