### PR TITLE
Improvement of StringMatchExtractor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langcheck"
-version = "0.10.0.dev5"
+version = "0.10.0.dev6"
 description = "Simple, Pythonic building blocks to evaluate LLM-based applications"
 readme = "README.md"
 authors = [{ name = "Citadel AI", email = "info@citadel.co.jp" }]

--- a/src/langcheck/__init__.py
+++ b/src/langcheck/__init__.py
@@ -1,4 +1,4 @@
 from langcheck import augment, metrics, plot, utils
 
 __all__ = ["augment", "metrics", "plot", "utils"]
-__version__ = "0.10.0.dev5"
+__version__ = "0.10.0.dev6"

--- a/src/langcheck/metrics/eval_clients/extractor/string_match_extractor.py
+++ b/src/langcheck/metrics/eval_clients/extractor/string_match_extractor.py
@@ -47,6 +47,9 @@ class StringMatchExtractor(Extractor):
                 continue
 
             # Find the option that appears latest in the assessment
+            # In case an option is a substring of another option, the options
+            # are sorted in descending order of length.
+            options.sort(key=len, reverse=True)
             assessment = max(options, key=unstructured_assessment.rfind)
             if unstructured_assessment.find(assessment) == -1:
                 print("No options found in the assessment.")


### PR DESCRIPTION
`StringMatchExtractor` returns an option that is found at the right-most position of the unstructured assessment.
However, it only checks the position of the first character of the options, so it shows a weird behavior if an option is a substring of another one.

For example, if the unstructured assessment is `Result: 0.5` and the options are `['0', '0.5', '1.0']`, the extracted value is `0`.

If two strings match at the same index, the longest option is returned instead. This PR achieves that by sorting the options before the extraction.