### PR TITLE
Unpin the version of transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     'tomli; python_version < "3.11"',
     'tokenizers >= 0.13.2; python_version >= "3.11"',  # See https://github.com/citadel-ai/langcheck/pull/45
     'torch >= 2',
-    'transformers >= 4.6, < 4.52.1',
+    'transformers >= 4.6',
     'tabulate >= 0.9.0', # For model manager print table
     'omegaconf >= 2.3.0' # For model manager print table
 ]


### PR DESCRIPTION
A bug related to our testing pipeline is patched in [transformers v4.53.0](https://github.com/huggingface/transformers/releases/tag/v4.53.0) so we unpin the version of the library.