### PR TITLE
Support pairwise custom metrics with custom inputs

### DIFF
--- a/src/langcheck/metrics/custom_text_quality.py
+++ b/src/langcheck/metrics/custom_text_quality.py
@@ -125,6 +125,13 @@ def custom_pairwise_evaluator(
     template_path: str,
     language: str,
     enforce_consistency: bool = True,
+    *,
+    additional_inputs: dict[
+        str,
+        IndividualInputType | tuple[IndividualInputType, IndividualInputType],
+    ]
+    | None = None,
+    additional_input_name_to_prompt_var_mapping: dict[str, str] | None = None,
 ) -> MetricValue[float | None]:
     """Calculates the scores of a custom pairwise evaluator, where "pairwise"
     means that the Responses and/or Sources of two systems will be compared
@@ -191,6 +198,8 @@ def custom_pairwise_evaluator(
         prompts=prompts,
         sources=(sources_a, sources_b),
         reference_outputs=reference_outputs,
+        additional_inputs=additional_inputs,
+        additional_input_name_to_prompt_var_mapping=additional_input_name_to_prompt_var_mapping,
         required_params=[],
     )
 

--- a/src/langcheck/metrics/metric_inputs.py
+++ b/src/langcheck/metrics/metric_inputs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import Mapping, Union
 
 import pandas as pd
 from jinja2 import Environment, meta
@@ -379,7 +379,11 @@ def get_metric_inputs(
     | tuple[IndividualInputType, IndividualInputType] = None,
     reference_outputs: IndividualInputType
     | tuple[IndividualInputType, IndividualInputType] = None,
-    additional_inputs: dict[str, IndividualInputType] | None = None,
+    additional_inputs: Mapping[
+        str,
+        IndividualInputType | tuple[IndividualInputType, IndividualInputType],
+    ]
+    | None = None,
     additional_input_name_to_prompt_var_mapping: dict[str, str] | None = None,
     required_params: list[str],
 ) -> MetricInputs:
@@ -458,7 +462,11 @@ def get_metric_inputs_with_required_lists(
     | tuple[IndividualInputType, IndividualInputType] = None,
     reference_outputs: IndividualInputType
     | tuple[IndividualInputType, IndividualInputType] = None,
-    additional_inputs: dict[str, IndividualInputType] | None = None,
+    additional_inputs: Mapping[
+        str,
+        IndividualInputType | tuple[IndividualInputType, IndividualInputType],
+    ]
+    | None = None,
     additional_input_name_to_prompt_var_mapping: dict[str, str] | None = None,
     required_params: list[str],
 ) -> tuple[MetricInputs, list[list[str]]]:


### PR DESCRIPTION
I noticed that our `custom_pairwise_evaluator` does not load any custom inputs.

This PR updates the function so that it accepts the additional metric inputs.

I tested the behavior with the following test scripts:
```
あなたは英語から日本語への翻訳のスタイル変換を評価しています。二つのスタイル変換の品質を比較してください。

データは以下の通りです:
[BEGIN DATA]
************
[ユーザーの入力]: {{ user_query }}
************
[元の翻訳]: {{ original_translation }}
************
[指示されたスタイル] {{ style }}
************
[変換後の翻訳 A]: {{ updated_translation_a }}
************
[変換後の翻訳 B]: {{ updated_translation_b }}
************
[END DATA]

利用可能な評価は以下の通りです:
`0` - 変換後の翻訳 Aがより良い回答です。
`1` - 変換後の翻訳 Bがより良い回答です。
`0.5` - 2つの回答は品質がほぼ同等です。

深呼吸をして、この問題にステップバイステップで取り組んでください。まずは考えているプロセスを出力し、最後に答えを提供してください。
```

```python
import os

from dotenv import load_dotenv

from langcheck.metrics import custom_pairwise_evaluator
from langcheck.metrics.eval_clients import LiteLLMEvalClient


def init_client():
    return LiteLLMEvalClient(
        model="gpt-4o-mini",
        embedding_model="text-embedding-3-small",
        api_key=os.getenv("OPENAI_API_KEY"),
        use_async=True,
    )


if __name__ == "__main__":
    load_dotenv()

    client = init_client()
    eval_result = custom_pairwise_evaluator(
        generated_outputs_a=None,
        generated_outputs_b=None,
        prompts="I love you",
        sources_a=None,
        sources_b=None,
        reference_outputs=None,
        eval_model=client,
        metric_name="pairwise_style_eval",
        template_path="test_pairwise_style_eval.j2",
        language="ja",
        score_map={
            "0": 0,
            "0.5": 0.5,
            "1": 1,
        },
        additional_inputs={
            "orig_translation": "私はあなたを愛しています",
            "style": "formal",
            "upd_translation": (
                "当方はあなたを愛しています。",
                "月が綺麗ですね。",
            ),
        },
        additional_input_name_to_prompt_var_mapping={
            "orig_translation": "original_translation",
            "upd_translation": "updated_translation",
        },
    )
    breakpoint()

```