### PR TITLE
Unpin sentence-transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     'plotly >= 5',
     'requests',
     'rouge-score >= 0.1.2',
-    'sentence-transformers >= 2, < 4',
+    'sentence-transformers >= 2',
     'sentencepiece>=0.1.95',
     'tomli; python_version < "3.11"',
     'tokenizers >= 0.13.2; python_version >= "3.11"',  # See https://github.com/citadel-ai/langcheck/pull/45


### PR DESCRIPTION
We pinned `sentence-transformers` to `< 4` half a year ago due to some typing errors(https://github.com/citadel-ai/langcheck/pull/190/commits/a8cfcd20e79938e05ad133f78206d0cc4c76cbd5), but the version got a bit outdated (the latest version is 5.1.0)

https://pypi.org/project/sentence-transformers/#history

I tried unpin the version and it seems to work fine at least in our unit tests. Let's unpin the version then.