### PR TITLE
Remove upper bound on transformers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.9-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.10-bullseye",
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// PyTorch 2.1.0 causes segmentation fault in aarch64, so we pin the version in the dev container until the bug is fixed.
 	// Ref: https://github.com/pytorch/pytorch/issues/110819

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -20,10 +20,10 @@ jobs:
       # Checks out this repository so this job can access it
       - uses: actions/checkout@v2
 
-      # Use Python 3.9.19
+      # Use Python 3.10
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9.19'
+          python-version: '3.10'
 
       # Install the langcheck package with dev dependencies
       - name: Install

--- a/.github/workflows/pip_install_matrix.yml
+++ b/.github/workflows/pip_install_matrix.yml
@@ -17,17 +17,13 @@ jobs:
       fail-fast: false  # Continue running jobs even if another fails
       matrix:
         # We specify Python versions as strings so 3.10 doesn't become 3.1
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-14]
         # "en", "de", and "" are equivalent
         # "all" is tested by pytest.yml
         language: ["en", "ja", "zh"]
 
         exclude:
-          # GitHub Actions doesn't support Python 3.9 on M1 macOS yet:
-          # https://github.com/actions/setup-python/issues/696
-          - python-version: "3.9"
-            os: macos-14
           # TODO: Figure out how to install MeCab on Windows to install
           # LangCheck on Python 3.12 since there are no wheels for `fugashi`
           - python-version: "3.12"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,10 +26,10 @@ jobs:
       # Checks out this repository so this job can access it
       - uses: actions/checkout@v4
 
-      # Use Python 3.9.19
+      # Use Python 3.10
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9.19'
+          python-version: '3.10'
 
       # Install the langcheck package with dev dependencies
       - name: Install

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
    configuration: docs/conf.py

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ pip install --upgrade pip
 pip install langcheck[all]
 ```
 
-LangCheck works with Python 3.9 or higher.
+LangCheck works with Python 3.10 or higher.
 
 :::{note}
 Model files are lazily downloaded the first time you run a metric function. For example, the first time you run the ``langcheck.metrics.sentiment()`` function, LangCheck will automatically download the Twitter-roBERTa-base model.

--- a/docs/tutorial_langcheckchat.md
+++ b/docs/tutorial_langcheckchat.md
@@ -69,7 +69,7 @@ Here’s the response from the LLM:
 >
 > pip install langcheck
 >
-> Please note that LangCheck requires Python 3.9 or higher to work properly.
+> Please note that LangCheck requires Python 3.10 or higher to work properly.
 
 We can also see the sources that were retrieved from the index. By default, the top 2 most relevant source nodes are returned, which is what we see in `response.source_nodes`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     'tabulate >= 0.9.0', # For model manager print table
     'omegaconf >= 2.3.0' # For model manager print table
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 de = []  # No extra dependencies needed for German

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     'tomli; python_version < "3.11"',
     'tokenizers >= 0.13.2; python_version >= "3.11"',  # See https://github.com/citadel-ai/langcheck/pull/45
     'torch >= 2',
-    'transformers >= 4.6, < 4.54.0',  # See https://github.com/vllm-project/vllm-ascend/issues/2046
+    'transformers >= 4.6',
     'tabulate >= 0.9.0', # For model manager print table
     'omegaconf >= 2.3.0' # For model manager print table
 ]


### PR DESCRIPTION
Removed the upper bound on the `transformers` version since https://github.com/vllm-project/vllm-ascend/issues/2046 was resolved.

Also, the latest transformers dropped support for Python 3.9 (which reached EOL in October 2025), which was breaking the tests. Also updated the tests and minimum Python version to 3.10. 